### PR TITLE
Add rancher-turtles for testing in SV

### DIFF
--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/basic-setup.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/basic-setup.sh
@@ -19,6 +19,8 @@ export METAL3_RKE2CONTROLPLANENAMESPACE="rke2-control-plane-system"
 # Use "false" to avoid creating the ~/.cluster-api/clusterctl.yaml file
 # The upstream one is: registry.opensuse.org/isv/suse/edge/clusterapi/containerfile/suse
 export METAL3_CAPI_IMAGES="registry.suse.com/edge"
+export RANCHER_TURTLES_TARGETNAMESPACE="rancher-turtles-system"
+export RANCHER_TURTLES_VERSION="0.1.0+up0.9.1"
 
 ###########
 # METALLB #

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
@@ -66,25 +66,6 @@ if [ $(${KUBECTL} get svc -n ${METAL3_CHART_TARGETNAMESPACE} metal3-metal3-ironi
 	EOF
 fi
 
-# If clusterctl is not installed, install it
-if ! command -v clusterctl > /dev/null 2>&1; then
-  LINUXARCH=$(uname -m)
-  case $(uname -m) in
-    "x86_64")
-      export GOARCH="amd64" ;;
-    "aarch64")
-      export GOARCH="arm64" ;;
-    "*")
-      echo "Arch not found, asumming amd64"
-      export GOARCH="amd64" ;;
-  esac
-
-  # Clusterctl bin
-  # Maybe just use the binary from hauler if available
-  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v${METAL3_CLUSTERCTLVERSION}/clusterctl-linux-${GOARCH} -o /usr/local/bin/clusterctl
-  chmod +x /usr/local/bin/clusterctl
-fi
-
 # If rancher is deployed
 if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
   cat <<-EOF | ${KUBECTL} apply -f -
@@ -103,44 +84,12 @@ if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o
 fi
 
 # Deploy CAPI
-if [ $(${KUBECTL} get pods -n ${METAL3_CAPISYSTEMNAMESPACE} -o name | wc -l) -lt 1 ]; then
+#### There's an issue (https://github.com/rancher/turtles/issues/627) in the original helm-chart that makes it fail to deploy the CAPI controller using the EIB definition file, so we need to deploy it manually here
 
-  if [ ${METAL3_CAPI_IMAGES} != "false" ]; then
-    # https://github.com/rancher-sandbox/cluster-api-provider-rke2#setting-up-clusterctl
-    mkdir -p ~/.cluster-api
-    cat <<-EOF > ~/.cluster-api/clusterctl.yaml
-		images:
-		  all:
-		    repository: ${METAL3_CAPI_IMAGES}
-		EOF
-  fi
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+helm repo add github-suse-edge-charts https://suse-edge.github.io/charts
+helm install --namespace ${RANCHER_TURTLES_TARGETNAMESPACE} --create-namespace --version ${RANCHER_TURTLES_VERSION} rancher-turtles github-suse-edge-charts/rancher-turtles
 
-  # Try this command 3 times just in case, stolen from https://stackoverflow.com/a/33354419
-  if ! (r=3; while ! clusterctl init \
-    --core "cluster-api:v${METAL3_CAPICOREVERSION}"\
-    --infrastructure "metal3:v${METAL3_CAPIMETAL3VERSION}"\
-    --bootstrap "${METAL3_CAPIPROVIDER}:v${METAL3_CAPIRKE2VERSION}"\
-    --control-plane "${METAL3_CAPIPROVIDER}:v${METAL3_CAPIRKE2VERSION}" ; do
-            ((--r))||exit
-            echo "Something went wrong, let's wait 10 seconds and retry"
-            sleep 10;done) ; then
-      echo "clusterctl failed"
-      exit 1
-  fi
-
-  # Wait for capi-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CAPISYSTEMNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CAPISYSTEMNAMESPACE} -l cluster.x-k8s.io/provider=cluster-api -o name) --timeout=10s; do sleep 2 ; done
-
-  # Wait for capm3-controller-manager, there are two pods, the ipam and the capm3 one, just wait for the first one
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CAPM3NAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CAPM3NAMESPACE} -l cluster.x-k8s.io/provider=infrastructure-metal3 -o name | head -n1 ) --timeout=10s; do sleep 2 ; done
-
-  # Wait for rke2-bootstrap-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_RKE2BOOTSTRAPNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_RKE2BOOTSTRAPNAMESPACE} -l cluster.x-k8s.io/provider=bootstrap-rke2 -o name) --timeout=10s; do sleep 2 ; done
-
-  # Wait for rke2-control-plane-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_RKE2CONTROLPLANENAMESPACE} $(${KUBECTL} get pods -n ${METAL3_RKE2CONTROLPLANENAMESPACE} -l cluster.x-k8s.io/provider=control-plane-rke2 -o name) --timeout=10s; do sleep 2 ; done
-
-fi
 
 # Clean up the lock cm
 

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/files/basic-setup.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/files/basic-setup.sh
@@ -19,6 +19,8 @@ export METAL3_RKE2CONTROLPLANENAMESPACE="rke2-control-plane-system"
 # Use "false" to avoid creating the ~/.cluster-api/clusterctl.yaml file
 # The upstream one is: registry.opensuse.org/isv/suse/edge/clusterapi/containerfile/suse
 export METAL3_CAPI_IMAGES="registry.suse.com/edge"
+export RANCHER_TURTLES_TARGETNAMESPACE="rancher-turtles-system"
+export RANCHER_TURTLES_VERSION="0.1.0+up0.9.1"
 
 ###########
 # RANCHER #

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/files/metal3.sh
@@ -28,25 +28,6 @@ fi
 # Wait for metal3
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
-# If clusterctl is not installed, install it
-if ! command -v clusterctl > /dev/null 2>&1; then
-  LINUXARCH=$(uname -m)
-  case $(uname -m) in
-    "x86_64")
-      export GOARCH="amd64" ;;
-    "aarch64")
-      export GOARCH="arm64" ;;
-    "*")
-      echo "Arch not found, asumming amd64"
-      export GOARCH="amd64" ;;
-  esac
-
-  # Clusterctl bin
-  # Maybe just use the binary from hauler if available
-  curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v${METAL3_CLUSTERCTLVERSION}/clusterctl-linux-${GOARCH} -o /usr/local/bin/clusterctl
-  chmod +x /usr/local/bin/clusterctl
-fi
-
 # If rancher is deployed
 if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
   cat <<-EOF | ${KUBECTL} apply -f -
@@ -65,44 +46,11 @@ if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o
 fi
 
 # Deploy CAPI
-if [ $(${KUBECTL} get pods -n ${METAL3_CAPISYSTEMNAMESPACE} -o name | wc -l) -lt 1 ]; then
+#### There's an issue (https://github.com/rancher/turtles/issues/627) in the original helm-chart that makes it fail to deploy the CAPI controller using the EIB definition file, so we need to deploy it manually here
 
-  if [ ${METAL3_CAPI_IMAGES} != "false" ]; then
-    # https://github.com/rancher-sandbox/cluster-api-provider-rke2#setting-up-clusterctl
-    mkdir -p ~/.cluster-api
-    cat <<-EOF > ~/.cluster-api/clusterctl.yaml
-		images:
-		  all:
-		    repository: ${METAL3_CAPI_IMAGES}
-		EOF
-  fi
-
-  # Try this command 3 times just in case, stolen from https://stackoverflow.com/a/33354419
-  if ! (r=3; while ! clusterctl init \
-    --core "cluster-api:v${METAL3_CAPICOREVERSION}"\
-    --infrastructure "metal3:v${METAL3_CAPIMETAL3VERSION}"\
-    --bootstrap "${METAL3_CAPIPROVIDER}:v${METAL3_CAPIRKE2VERSION}"\
-    --control-plane "${METAL3_CAPIPROVIDER}:v${METAL3_CAPIRKE2VERSION}" ; do
-            ((--r))||exit
-            echo "Something went wrong, let's wait 10 seconds and retry"
-            sleep 10;done) ; then
-      echo "clusterctl failed"
-      exit 1
-  fi
-
-  # Wait for capi-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CAPISYSTEMNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CAPISYSTEMNAMESPACE} -l cluster.x-k8s.io/provider=cluster-api -o name) --timeout=10s; do sleep 2 ; done
-
-  # Wait for capm3-controller-manager, there are two pods, the ipam and the capm3 one, just wait for the first one
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CAPM3NAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CAPM3NAMESPACE} -l cluster.x-k8s.io/provider=infrastructure-metal3 -o name | head -n1 ) --timeout=10s; do sleep 2 ; done
-
-  # Wait for rke2-bootstrap-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_RKE2BOOTSTRAPNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_RKE2BOOTSTRAPNAMESPACE} -l cluster.x-k8s.io/provider=bootstrap-rke2 -o name) --timeout=10s; do sleep 2 ; done
-
-  # Wait for rke2-control-plane-controller-manager
-  while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_RKE2CONTROLPLANENAMESPACE} $(${KUBECTL} get pods -n ${METAL3_RKE2CONTROLPLANENAMESPACE} -l cluster.x-k8s.io/provider=control-plane-rke2 -o name) --timeout=10s; do sleep 2 ; done
-
-fi
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+helm repo add github-suse-edge-charts https://suse-edge.github.io/charts
+helm install --namespace ${RANCHER_TURTLES_TARGETNAMESPACE} --create-namespace --version ${RANCHER_TURTLES_VERSION} rancher-turtles github-suse-edge-charts/rancher-turtles
 
 # Clean up the lock cm
 


### PR DESCRIPTION
- Add the rancher-turtles to the current 3.0.2 release versions. 
- The idea is to share with SV to test it and prepare piplines to test it with the final 3.1 release version first @fdegir 

Please don't merge it 