### PR TITLE
[WIP] Disable cilium exclusive mode with multus

### DIFF
--- a/telco-examples/edge-clusters/airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/telco-capi-airgap.yaml
@@ -201,6 +201,25 @@ spec:
                 name: root
               group:
                 name: root
+            # https://docs.rke2.io/networking/multus_sriov#using-multus-with-cilium
+            - path: /var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChartConfig
+                  metadata:
+                    name: rke2-cilium
+                    namespace: kube-system
+                  spec:
+                    valuesContent: |-
+                      cni:
+                        exclusive: false
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
             - path: /var/sriov-auto-filler.sh
               overwrite: true
               contents:


### PR DESCRIPTION
To align with https://docs.rke2.io/networking/multus_sriov#using-multus-with-cilium

In the long term it may be desirable to set this automatically via the RKE2 CAPI provider, but this seems like the simplest way to achieve the recommended configuration for now.