### PR TITLE
add v1beta1 change to all examples

### DIFF
--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -34,7 +34,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -53,7 +53,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -64,6 +64,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   privateRegistriesConfig:       # Private registry configuration to add your own mirror and credentials
     mirrors:
       docker.io:
@@ -289,7 +295,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -43,6 +43,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -86,7 +92,6 @@ spec:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
         - "--config=/etc/kubernetes/kubeletconfig.yml"
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
@@ -12,7 +12,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
@@ -31,7 +31,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -42,7 +42,12 @@ spec:
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
-  registrationMethod: "address"
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   registrationAddress: ${EDGE_VIP_ADDRESS}
   serverConfig:
     cni: cilium
@@ -158,7 +163,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "Node-multinode-cluster"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -43,6 +43,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -204,7 +210,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -43,6 +43,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -289,7 +295,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
@@ -12,7 +12,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
@@ -31,7 +31,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -42,7 +42,12 @@ spec:
     kind: Metal3MachineTemplate
     name: multinode-cluster-controlplane
   replicas: 3
-  registrationMethod: "address"
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   registrationAddress: ${EDGE_VIP_ADDRESS}
   serverConfig:
     cni: cilium
@@ -178,7 +183,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "Node-multinode-cluster"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -43,6 +43,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -204,7 +210,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
         - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
@@ -32,7 +32,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
@@ -43,6 +43,12 @@ spec:
     kind: Metal3MachineTemplate
     name: single-node-cluster-controlplane
   replicas: 1
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
   serverConfig:
     cni: calico
     cniMultusEnable: true
@@ -285,7 +291,6 @@ spec:
     kubelet:
       extraArgs:
         - provider-id=metal3://BAREMETALHOST_UUID
-    version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Add the following changes:

- adding the spec.rolloutStrategy (https://github.com/rancher-sandbox/cluster-api-provider-rke2/blob/main/docs/adr/0002-deprecate-kubebuilder-defaults.md) to the RKE2ControlPlane resource
- move the version from RKE2ControlPlane.Spec.AgentConfig.Version  to  RKE2ControlPlane.Spec.Version
- change all the references from v1alpha1 to v1beta1 for the rke2controlplane object, for example in the cluster object:
remove the RKE2ConfigTemplate.spec.template.spec.agentConfig.version
- Also see https://github.com/rancher/cluster-api-provider-rke2/blob/main/docs/adr/0001-separate-CP-and-worker-versions.md