### PR TITLE
remove repo not needed with 6.1

### DIFF
--- a/telco-examples/edge-clusters/aarch64/eib/telco-edge-cluster-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/eib/telco-edge-cluster-aarch64.yaml
@@ -30,6 +30,4 @@ operatingSystem:
       - tuned
       - cpupower
       - openssh-server-config-rootlogin
-    additionalRepos:
-      - url: https://download.opensuse.org/repositories/isv:/SUSE:/Edge:/Telco/SL-Micro_6.1_images/
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}


### PR DESCRIPTION
- With slmicro6.1 we don't need to maintain the pf_bb_config package because it has been included as a part of the 6.1 repos