### PR TITLE
modify dhcp examples to add the mac identifier and minor name fixes

### DIFF
--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/bmh-example.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/bmh-example.yaml
@@ -40,7 +40,7 @@ stringData:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: airgap-demo
+  name: example-demo
   labels:
     cluster-role: control-plane
 spec:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node1-example.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node1-example.yaml
@@ -19,6 +19,7 @@ stringData:
       type: ethernet
       state: up
       mtu: 1500
+      identifier: mac-address
       mac-address: "${CONTROLPLANE1_MAC}"
       ipv4:
         address:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node2-example.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node2-example.yaml
@@ -19,6 +19,7 @@ stringData:
       type: ethernet
       state: up
       mtu: 1500
+      identifier: mac-address
       mac-address: "${CONTROLPLANE2_MAC}"
       ipv4:
         address:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node3-example.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/bmh-node3-example.yaml
@@ -19,6 +19,7 @@ stringData:
       type: ethernet
       state: up
       mtu: 1500
+      identifier: mac-address
       mac-address: "${CONTROLPLANE3_MAC}"
       ipv4:
         address:

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/bmh-example.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/bmh-example.yaml
@@ -20,6 +20,7 @@ stringData:
       type: ethernet
       state: up
       mtu: 1500
+      identifier: mac-address
       mac-address: "${CONTROLPLANE_MAC}"
       ipv4:
         address:
@@ -40,7 +41,7 @@ stringData:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: flexran-demo
+  name: example-demo
   labels:
     cluster-role: control-plane
 spec:

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/bmh-example.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/bmh-example.yaml
@@ -11,7 +11,7 @@ data:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: flexran-demo
+  name: example-demo
   labels:
     cluster-role: control-plane
 spec:


### PR DESCRIPTION
- Modify the dhcp-less examples to add the mac identifier
- Should be backported to 3.1 where the network script was changed
- renaming all bmh name objects to example-demo