### PR TITLE
update to 3.2

### DIFF
--- a/telco-examples/edge-clusters/README.md
+++ b/telco-examples/edge-clusters/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This is an example to demonstrate how to deploy an edge cluster for Telco using SUSE ATIP and the fully automated directed network provisioning.
+This is an example to demonstrate how to deploy an edge cluster using SUSE Edge for Telco (formerly known as ATIP) and the fully automated directed network provisioning.
 
 There are two steps to deploy an edge cluster:
 
@@ -38,7 +38,7 @@ All the following commands in this section could be executed using any linux lap
 ```
 $ cd telco-examples/edge-clusters
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file telco-edge-cluster.yaml
 ```
 

--- a/telco-examples/edge-clusters/aarch64/README.md
+++ b/telco-examples/edge-clusters/aarch64/README.md
@@ -40,7 +40,7 @@ All the following commands in this section could be executed using any linux lap
 ```
 $ cd telco-examples/edge-clusters/aarch64/eib
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file telco-edge-cluster-aarch64.yaml
 ```
 

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -99,9 +99,9 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-crd-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-crd-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
               overwrite: true
@@ -113,9 +113,9 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-network-operator-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-network-operator-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
         kernel_arguments:
           should_exist:

--- a/telco-examples/edge-clusters/airgap/README.md
+++ b/telco-examples/edge-clusters/airgap/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This is an example to demonstrate how to deploy an air-gap downstream/edge cluster for Telco using SUSE ATIP and the fully automated directed network provisioning.
+This is an example to demonstrate how to deploy an air-gap downstream/edge cluster using SUSE Edge for Telco (formerly known as ATIP) and the fully automated directed network provisioning.
 
 There are two steps to deploy an edge cluster:
 
@@ -37,7 +37,7 @@ You need to modify the following folder:
 The following steps are required to prepare the airgap artifacts:
 
 1.Include the rke2 release images to the `custom/files` folder to be consumed by EIB during the build process. 
-  - You can use the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-save-rke2-images.sh) and the list of images [here](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-release-rke2-images.txt) to generate the artifacts required to be included in `custom/files`. 
+  - You can use the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-save-rke2-images.sh) and the list of images [here](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-release-rke2-images.txt) to generate the artifacts required to be included in `custom/files`. 
   ```
   $ ./edge-save-rke2-images.sh -o ~/telco-examples/edge-clusters/airgap/eib/custom/files -l ~/edge-release-rke2-images.txt
   ...
@@ -56,52 +56,52 @@ The following steps are required to prepare the airgap artifacts:
   - You need to create a list with the Helm charts required for the edge cluster. For example, for telco scenarios, you can use the following list:
     ``` 
     $ cat > edge-release-helm-oci-artifacts.txt <<EOF
-    edge/sriov-network-operator-chart:1.3.0
-    edge/sriov-crd-chart:1.3.0
+    edge/sriov-network-operator-chart:302.0.0+up1.4.0
+    edge/sriov-crd-chart:302.0.0+up1.4.0
     EOF
     ```
-  - Using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-save-oci-artefacts.sh) and the list created above, you can generate a tarball containing all necessary Helm charts locally.
+  - Using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-save-oci-artefacts.sh) and the list created above, you can generate a tarball containing all necessary Helm charts locally.
     ```
     $ ./edge-save-oci-artefacts.sh -al ./edge-release-helm-oci-artifacts.txt -s registry.suse.com
-    Pulled: registry.suse.com/edge/sriov-network-operator-chart:1.3.0
-    Pulled: registry.suse.com/edge/sriov-crd-chart:1.3.0
-    a edge-release-oci-tgz-20241016
-    a edge-release-oci-tgz-20241016/sriov-network-operator-chart-1.3.0.tgz
-    a edge-release-oci-tgz-20241016/sriov-crd-chart-1.3.0.tgz
+    Pulled: registry.suse.com/edge/sriov-network-operator-chart:302.0.0+up1.4.0
+    Pulled: registry.suse.com/edge/sriov-crd-chart:302.0.0+up1.4.0
+    a edge-release-oci-tgz-20250120
+    a edge-release-oci-tgz-20250120/sriov-network-operator-chart-302.0.0+up1.4.0.tgz
+    a edge-release-oci-tgz-20250120/sriov-crd-chart-302.0.0+up1.4.0.tgz
     ```
-  - Upload your tarball to your private registry to preload with the helm chart oci images downloaded using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-load-oci-artefacts.sh):
+  - Upload your tarball to your private registry to preload with the helm chart oci images downloaded using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-load-oci-artefacts.sh):
     ```
-    $ tar zxvf edge-release-oci-tgz-20241016.tgz
-    $ ./edge-load-oci-artefacts.sh -ad edge-release-oci-tgz-20241016 -r myregistry:5000
+    $ tar zxvf edge-release-oci-tgz-20250120.tgz
+    $ ./edge-load-oci-artefacts.sh -ad edge-release-oci-tgz-20250120 -r myregistry:5000
     ```
 
 3. Preload your registry with the necessary container images (including your workload ones) required for the edge cluster. 
-  - In this example, we need to include the sriov container images for telco workload (you can get the images from the [helm-chart values](https://github.com/suse-edge/charts/blob/main/charts/sriov-network-operator/1.3.0/values.yaml))
+  - In this example, we need to include the sriov container images for telco workload (you can get the images from the [helm-chart values](https://github.com/suse-edge/charts/blob/main/charts/sriov-network-operator/1.4.0/values.yaml))
     ``` 
     $ cat > edge-release-images.txt <<EOF
-    rancher/hardened-sriov-network-operator:v1.3.0-build20240816
-    rancher/hardened-sriov-network-config-daemon:v1.3.0-build20240816
-    rancher/hardened-sriov-cni:v2.8.1-build20240820
-    rancher/hardened-ib-sriov-cni:v1.1.1-build20240816
-    rancher/hardened-sriov-network-device-plugin:v3.7.0-build20240816
-    rancher/hardened-sriov-network-resources-injector:v1.6.0-build20240816
-    rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
+    rancher/hardened-sriov-network-operator:v1.4.0-build20241113
+    rancher/hardened-sriov-network-config-daemon:v1.4.0-build20241113
+    rancher/hardened-sriov-cni:v2.8.1-build20241113
+    rancher/hardened-ib-sriov-cni:v1.1.1-build20241113
+    rancher/hardened-sriov-network-device-plugin:v3.8.0-build20241114
+    rancher/hardened-sriov-network-resources-injector:v1.6.0-build20241113
+    rancher/hardened-sriov-network-webhook:v1.4.0-build20241113
     EOF
     ```
-  - Using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-save-images.sh) and the list created above, you can generate in local the tarball with the images required for the edge cluster.
+  - Using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-save-images.sh) and the list created above, you can generate in local the tarball with the images required for the edge cluster.
     ```
     $ ./edge-save-images.sh -l ./edge-release-images.txt -s registry.suse.com
-    Image pull success: registry.suse.com/rancher/hardened-sriov-network-operator:v1.3.0-build20240816
-    Image pull success: registry.suse.com/rancher/hardened-sriov-network-config-daemon:v1.3.0-build20240816
-    Image pull success: registry.suse.com/rancher/hardened-sriov-cni:v2.8.1-build20240820
-    Image pull success: registry.suse.com/rancher/hardened-ib-sriov-cni:v1.1.1-build20240816
-    Image pull success: registry.suse.com/rancher/hardened-sriov-network-device-plugin:v3.7.0-build20240816
-    Image pull success: registry.suse.com/rancher/hardened-sriov-network-resources-injector:v1.6.0-build20240816
-    Image pull success: registry.suse.com/rancher/hardened-sriov-network-webhook:v1.3.0-build20240816
+    Image pull success: registry.suse.com/rancher/hardened-sriov-network-operator:v1.4.0-build20241113
+    Image pull success: registry.suse.com/rancher/hardened-sriov-network-config-daemon:v1.4.0-build20241113
+    Image pull success: registry.suse.com/rancher/hardened-sriov-cni:v2.8.1-build20241113
+    Image pull success: registry.suse.com/rancher/hardened-ib-sriov-cni:v1.1.1-build20241113
+    Image pull success: registry.suse.com/rancher/hardened-sriov-network-device-plugin:v3.8.0-build20241114
+    Image pull success: registry.suse.com/rancher/hardened-sriov-network-resources-injector:v1.6.0-build20241113
+    Image pull success: registry.suse.com/rancher/hardened-sriov-network-webhook:v1.4.0-build20241113
     Creating edge-images.tar.gz with 7 images
     ```
     
-  - Upload your tarball to your private registry to preload with the images downloaded in the previous step using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.1/scripts/day2/edge-load-images.sh)
+  - Upload your tarball to your private registry to preload with the images downloaded in the previous step using the [following script](https://github.com/suse-edge/fleet-examples/blob/release-3.2/scripts/day2/edge-load-images.sh)
 
 
 ### Building the Edge Cluster Image using EIB
@@ -113,7 +113,7 @@ All the following commands in this section could be executed on any x86_64 Linux
 ```
 $ cd telco-examples/edge-clusters/airgap/eib
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file telco-edge-airgap-cluster.yaml
 ```
 
@@ -182,8 +182,8 @@ The first thing is to modify the `telco-capi-airgap.yaml` file and replace the f
 - `${PF_NAME1}` - The network interface or physical function (usually filters in the network interface) to be used for the SRIOV.
 - `${DRIVER_NAME1}` - The driver to be used for the interface and VFs (e.g `vfio-pci`).
 - `${NUM_VFS1}` - The number of VFs to be created for the network interface (e.g `2`).
-- `${SRIOV_CRD_VERSION}` - The version of the SRIOV CRD chart to be used for the edge cluster, for example `1.3.0`.
-- `${SRIOV_OPERATOR_VERSION}` - The version of the SRIOV Operator chart to be used for the edge cluster, for example, `1.3.0`.
+- `${SRIOV_CRD_VERSION}` - The version of the SRIOV CRD chart to be used for the edge cluster, for example `302.0.0+up1.4.0`.
+- `${SRIOV_OPERATOR_VERSION}` - The version of the SRIOV Operator chart to be used for the edge cluster, for example, `302.0.0+up1.4.0`.
 - `${ISOLATED_CPU_CORES}` - The isolated CPU cores to be used for workloads pinning some specific ones. You could get that info using `lscpu` command to list the CPU cores and then, select the cores to be used for the edge cluster in case you need CPU pinning for your workloads. For example, `1-18,21-38` could be used for the isolated cores.
 - `${NON-ISOLATED_CPU_CORES}` - The cores listed could be used shared for the rest of the process running on the edge cluster. For example, `0,20,21,39` could be used for the non-isolated cores.
 - `${CPU_FREQUENCY}` - The frequency to be used for the CPU cores. For example, `2500000` represents 2.5Ghz configuration and it could be used to set the CPU cores to the max performance.

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
@@ -91,9 +91,9 @@ spec:
                     name: endpoint-copier-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart
+                    chart: oci://registry.suse.com/edge/3.2/endpoint-copier-operator-chart
                     targetNamespace: endpoint-copier-operator
-                    version: 0.2.1
+                    version: 302.0.0+up0.2.1
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
               overwrite: true
@@ -105,9 +105,9 @@ spec:
                     name: metallb
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/metallb-chart
+                    chart: oci://registry.suse.com/edge/3.2/metallb-chart
                     targetNamespace: metallb-system
-                    version: 0.14.9
+                    version: 302.0.0+up0.14.9
                     createNamespace: true
 
             - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -104,9 +104,9 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-crd-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-crd-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
               overwrite: true
@@ -118,9 +118,9 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-network-operator-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-network-operator-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
         kernel_arguments:
           should_exist:

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/telco-capi-metallb-multi-node.yaml
@@ -111,9 +111,9 @@ spec:
                     name: endpoint-copier-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/endpoint-copier-operator-chart
+                    chart: oci://registry.suse.com/edge/3.2/endpoint-copier-operator-chart
                     targetNamespace: endpoint-copier-operator
-                    version: 0.2.1
+                    version: 302.0.0+up0.2.1
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
               overwrite: true
@@ -125,9 +125,9 @@ spec:
                     name: metallb
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/metallb-chart
+                    chart: oci://registry.suse.com/edge/3.2/metallb-chart
                     targetNamespace: metallb-system
-                    version: 0.14.9
+                    version: 302.0.0+up0.14.9
                     createNamespace: true
 
             - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -104,9 +104,9 @@ spec:
                     name: sriov-crd
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-crd-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-crd-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
             - path: /var/lib/rancher/rke2/server/manifests/sriov-network-operator.yaml
               overwrite: true
@@ -118,9 +118,9 @@ spec:
                     name: sriov-network-operator
                     namespace: kube-system
                   spec:
-                    chart: oci://registry.suse.com/edge/3.1/sriov-network-operator-chart
+                    chart: oci://registry.suse.com/edge/3.2/sriov-network-operator-chart
                     targetNamespace: sriov-network-operator
-                    version: 1.3.0
+                    version: 302.0.0+up1.4.0
                     createNamespace: true
         kernel_arguments:
           should_exist:

--- a/telco-examples/mgmt-cluster/aarch64/README.md
+++ b/telco-examples/mgmt-cluster/aarch64/README.md
@@ -1,10 +1,10 @@
 ## Tech-Preview AARCH64 Integration (full e2e, mgmt-cluster and downstream clusters using aarch64 architecture)
 
-This is an example to demonstrate how to deploy a management cluster for Telco using SUSE ATIP and the fully automated directed network provisioning using aarch64 architecture.
+This is an example to demonstrate how to deploy a management cluster for Telco using SUSE Edge for Telco (formerly known as ATIP) and the fully automated directed network provisioning using aarch64 architecture.
 
 # Management Cluster in a single-node setup (aarch64)
 
-This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE ATIP. The management cluster will contain the following components:
+This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE Edge for Telco. The management cluster will contain the following components:
 - SUSE Linux Micro 6.0 Kernel (SL Micro 6.0)
 - RKE2
 - CNI plugins (e.g. Multus, Cilium)
@@ -41,7 +41,7 @@ You need to modify the following values in the `custom/scripts/99-register.sh` f
 
 You need to modify the following folder:
 
-- `base-images` - To include inside the `SL-Micro.aarch64-6.0-Default-SelfInstall-GM.install.iso` image downloaded from the SUSE Customer Center.
+- `base-images` - To include inside the `SL-Micro.aarch64-6.0-Default-SelfInstall-GM2.install.iso` image downloaded from the SUSE Customer Center.
 
 ## Optional modifications
 
@@ -97,7 +97,7 @@ $ cd telco-examples/mgmt-cluster/aarch64/eib
 
 ```bash
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file mgmt-cluster-arm-singlenode.yaml
 ```
 

--- a/telco-examples/mgmt-cluster/aarch64/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/aarch64/eib/custom/files/rancher.sh
@@ -32,6 +32,7 @@ fi
 
 # Wait for rancher to be deployed
 while ! ${KUBECTL} wait --for condition=ready -n ${RANCHER_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name) --timeout=10s; do sleep 2 ; done
+until ${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher > /dev/null 2>&1; do sleep 10; done
 
 RANCHERBOOTSTRAPPASSWORD=$(${KUBECTL} get secret -n ${RANCHER_CHART_TARGETNAMESPACE} bootstrap-secret -o jsonpath='{.data.bootstrapPassword}' | base64 -d)
 RANCHERHOSTNAME=$(${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher -o jsonpath='{.spec.rules[0].host}')
@@ -48,13 +49,13 @@ if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{
   done
 
   # Set password
-  curl -sk ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
 
   # Create a temporary API token (ttl=60 minutes)
   APITOKEN=$(curl -sk ${RANCHERHOSTNAME}/v3/token -H 'content-type: application/json' -H "Authorization: Bearer ${TOKEN}" -d '{"type":"token","description":"automation","ttl":3600000}' | jq -r .token)
 
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
 fi
 
 # Clean up the lock cm

--- a/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
@@ -16,7 +16,7 @@ operatingSystem:
     - openssh-server-config-rootlogin
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}
 kubernetes:
-  version: v1.30.3+rke2r1
+  version: v1.31.3+rke2r1
   helm:
     charts:
       - name: cert-manager
@@ -27,14 +27,14 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
@@ -46,21 +46,21 @@ kubernetes:
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.1
+        version: v2.10.1
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
@@ -75,11 +75,11 @@ kubernetes:
     repositories:
       - name: jetstack
         url: https://charts.jetstack.io
-      - name: rancher-charts
+      - name: rancher
         url: https://charts.rancher.io/
       - name: suse-edge-upstream
         url: https://suse-edge.github.io/charts
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime

--- a/telco-examples/mgmt-cluster/airgap/README.md
+++ b/telco-examples/mgmt-cluster/airgap/README.md
@@ -1,7 +1,7 @@
 
 # Management Cluster in a single-node setup (air-gap scenario)
 
-This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE ATIP in an air-gap scenario. The management cluster will contain the following components:
+This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE Edge for Telco (formerly known as ATIP) in an air-gap scenario. The management cluster will contain the following components:
 - SUSE Linux Micro 6.0 Kernel (SL Micro 6.0)
 - RKE2
 - CNI plugins (e.g. Multus, Cilium)
@@ -93,7 +93,7 @@ $ cd telco-examples/mgmt-cluster/airgap/eib
 
 ```bash
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file mgmt-cluster-airgap.yaml
 ```
 

--- a/telco-examples/mgmt-cluster/airgap/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/airgap/eib/custom/files/rancher.sh
@@ -32,6 +32,7 @@ fi
 
 # Wait for rancher to be deployed
 while ! ${KUBECTL} wait --for condition=ready -n ${RANCHER_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name) --timeout=10s; do sleep 2 ; done
+until ${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher > /dev/null 2>&1; do sleep 10; done
 
 RANCHERBOOTSTRAPPASSWORD=$(${KUBECTL} get secret -n ${RANCHER_CHART_TARGETNAMESPACE} bootstrap-secret -o jsonpath='{.data.bootstrapPassword}' | base64 -d)
 RANCHERHOSTNAME=$(${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher -o jsonpath='{.spec.rules[0].host}')
@@ -48,13 +49,13 @@ if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{
   done
 
   # Set password
-  curl -sk ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
 
   # Create a temporary API token (ttl=60 minutes)
   APITOKEN=$(curl -sk ${RANCHERHOSTNAME}/v3/token -H 'content-type: application/json' -H "Authorization: Bearer ${TOKEN}" -d '{"type":"token","description":"automation","ttl":3600000}' | jq -r .token)
 
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
 fi
 
 # Clean up the lock cm

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,4 @@
-hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
+hostname: ${MGMT_CLUSTER_IP}
 bootstrapPassword: "foobar"
 replicas: 1
 global.cattle.psp.enabled: "false"

--- a/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
@@ -16,7 +16,7 @@ operatingSystem:
     - openssh-server-config-rootlogin
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}
 kubernetes:
-  version: v1.30.3+rke2r1
+  version: v1.31.3+rke2r1
   helm:
     charts:
       - name: cert-manager
@@ -27,54 +27,54 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.1
+        version: 302.0.0+up0.9.0
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.1
+        version: 2.10.1
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
       - name: rancher-turtles-chart
-        version: 0.3.2
+        version: 302.0.0+up0.14.1
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: turtles.yaml
-      - name: rancher-turtles-airgap-resources
-        version: 0.3.2
+      - name: rancher-turtles-airgap-resources-chart
+        version: 302.0.0+up0.14.1
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
@@ -82,81 +82,34 @@ kubernetes:
     repositories:
       - name: jetstack
         url: https://charts.jetstack.io
-      - name: rancher-charts
-        url: https://charts.rancher.io/
+      - name: rancher
+        url: https://charts.rancher.io
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
 embeddedArtifactRegistry:
   images:
-    - name: registry.rancher.com/rancher/backup-restore-operator:v5.0.1
-    - name: registry.rancher.com/rancher/calico-cni:v3.28.0-rancher1
-    - name: registry.rancher.com/rancher/cis-operator:v1.0.14
-    - name: registry.rancher.com/rancher/flannel-cni:v1.4.1-rancher1
-    - name: registry.rancher.com/rancher/fleet-agent:v0.10.1
-    - name: registry.rancher.com/rancher/fleet:v0.10.1
-    - name: registry.rancher.com/rancher/hardened-addon-resizer:1.8.20-build20240410
-    - name: registry.rancher.com/rancher/hardened-calico:v3.28.0-build20240625
-    - name: registry.rancher.com/rancher/hardened-cluster-autoscaler:v1.8.10-build20240124
-    - name: registry.rancher.com/rancher/hardened-cni-plugins:v1.4.1-build20240430
-    - name: registry.rancher.com/rancher/hardened-coredns:v1.11.1-build20240305
-    - name: registry.rancher.com/rancher/hardened-dns-node-cache:1.22.28-build20240125
-    - name: registry.rancher.com/rancher/hardened-etcd:v3.5.13-k3s1-build20240531
-    - name: registry.rancher.com/rancher/hardened-flannel:v0.25.4-build20240610
-    - name: registry.rancher.com/rancher/hardened-k8s-metrics-server:v0.7.1-build20240401
-    - name: registry.rancher.com/rancher/hardened-kubernetes:v1.30.3-rke2r1-build20240717
-    - name: registry.rancher.com/rancher/hardened-multus-cni:v4.0.2-build20240612
-    - name: registry.rancher.com/rancher/hardened-node-feature-discovery:v0.15.4-build20240513
-    - name: registry.rancher.com/rancher/hardened-whereabouts:v0.7.0-build20240429
-    - name: registry.rancher.com/rancher/helm-project-operator:v0.2.1
-    - name: registry.rancher.com/rancher/k3s-upgrade:v1.30.3-k3s1
-    - name: registry.rancher.com/rancher/klipper-helm:v0.8.4-build20240523
-    - name: registry.rancher.com/rancher/klipper-lb:v0.4.7
-    - name: registry.rancher.com/rancher/kube-api-auth:v0.2.2
-    - name: registry.rancher.com/rancher/kubectl:v1.29.7
-    - name: registry.rancher.com/rancher/local-path-provisioner:v0.0.28
-    - name: registry.rancher.com/rancher/machine:v0.15.0-rancher116
-    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.7.3
-    - name: registry.rancher.com/rancher/nginx-ingress-controller:v1.10.1-hardened1
-    - name: registry.rancher.com/rancher/prometheus-federator:v0.3.4
-    - name: registry.rancher.com/rancher/pushprox-client:v0.1.3-rancher2-client
-    - name: registry.rancher.com/rancher/pushprox-proxy:v0.1.3-rancher2-proxy
-    - name: registry.rancher.com/rancher/rancher-agent:v2.9.1
-    - name: registry.rancher.com/rancher/rancher-csp-adapter:v4.0.0
-    - name: registry.rancher.com/rancher/rancher-webhook:v0.5.1
-    - name: registry.rancher.com/rancher/rancher:v2.9.1
-    - name: registry.rancher.com/rancher/rke-tools:v0.1.100
-    - name: registry.rancher.com/rancher/rke2-cloud-provider:v1.29.3-build20240515
-    - name: registry.rancher.com/rancher/rke2-runtime:v1.30.3-rke2r1
-    - name: registry.rancher.com/rancher/rke2-upgrade:v1.30.3-rke2r1
-    - name: registry.rancher.com/rancher/security-scan:v0.2.16
-    - name: registry.rancher.com/rancher/shell:v0.2.1
-    - name: registry.rancher.com/rancher/system-agent-installer-k3s:v1.30.3-k3s1
-    - name: registry.rancher.com/rancher/system-agent-installer-rke2:v1.30.3-rke2r1
-    - name: registry.rancher.com/rancher/system-agent:v0.3.8-suc
-    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.13.4
-    - name: registry.rancher.com/rancher/ui-plugin-catalog:2.0.1
-    - name: registry.rancher.com/rancher/kubectl:v1.20.2
+    - name: registry.suse.com/rancher/cluster-api-controller:v1.8.4
+    - name: registry.suse.com/rancher/cluster-api-provider-rke2-bootstrap:v0.9.0
+    - name: registry.suse.com/rancher/cluster-api-provider-rke2-controlplane:v0.9.0
+    - name: registry.rancher.com/rancher/cluster-api-metal3-controller:v1.8.2
+    - name: registry.rancher.com/rancher/cluster-api-metal3-ipam-controller:v1.8.1
+    - name: registry.rancher.com/rancher/cluster-api-operator:v0.14.0
     - name: registry.rancher.com/rancher/kubectl:v1.29.2
-    - name: registry.rancher.com/rancher/shell:v0.1.24
-    - name: registry.suse.com/rancher/mirrored-longhornio-csi-attacher:v4.6.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-csi-provisioner:v4.0.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-csi-resizer:v1.11.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-csi-snapshotter:v7.0.2
-    - name: registry.suse.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
-    - name: registry.suse.com/rancher/mirrored-longhornio-livenessprobe:v2.14.0
-    - name: registry.suse.com/rancher/mirrored-longhornio-openshift-origin-oauth-proxy:4.15
-    - name: registry.suse.com/rancher/mirrored-longhornio-backing-image-manager:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-engine:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-manager:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-ui:v1.7.1
-    - name: registry.suse.com/rancher/mirrored-longhornio-support-bundle-kit:v0.0.42
-    - name: registry.suse.com/rancher/mirrored-longhornio-longhorn-cli:v1.7.1
-    - name: registry.suse.com/edge/3.1/cluster-api-provider-rke2-bootstrap:v0.7.0
-    - name: registry.suse.com/edge/3.1/cluster-api-provider-rke2-controlplane:v0.7.0
-    - name: registry.suse.com/edge/3.1/cluster-api-controller:v1.7.5
-    - name: registry.suse.com/edge/3.1/cluster-api-provider-metal3:v1.7.1
-    - name: registry.suse.com/edge/3.1/ip-address-manager:v1.7.1
+    - name: registry.rancher.com/rancher/fleet-agent:v0.11.2
+    - name: registry.rancher.com/rancher/fleet:v0.11.2
+    - name: registry.rancher.com/rancher/rancher-webhook:v0.6.2
+    - name: registry.rancher.com/rancher/mirrored-longhornio-csi-attacher:v4.7.0
+    - name: registry.rancher.com/rancher/mirrored-longhornio-csi-node-driver-registrar:v2.12.0
+    - name: registry.rancher.com/rancher/mirrored-longhornio-csi-provisioner:v4.0.1-20241007
+    - name: registry.rancher.com/rancher/mirrored-longhornio-csi-resizer:v1.12.0
+    - name: registry.rancher.com/rancher/mirrored-longhornio-csi-snapshotter:v7.0.2-20241007
+    - name: registry.rancher.com/rancher/mirrored-longhornio-livenessprobe:v2.14.0
+    - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-engine:v1.7.2
+    - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-instance-manager:v1.7.2
+    - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-manager:v1.7.2
+    - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-share-manager:v1.7.2
+    - name: registry.rancher.com/rancher/mirrored-longhornio-longhorn-ui:v1.7.2
+    - name: registry.rancher.com/rancher/system-upgrade-controller:v0.14.2
+    - name: registry.suse.com/rancher/seedimage-builder:1.6.4

--- a/telco-examples/mgmt-cluster/multi-node/README.md
+++ b/telco-examples/mgmt-cluster/multi-node/README.md
@@ -1,7 +1,7 @@
 
 # Management Cluster in a multi-node setup
 
-This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE ATIP. The management cluster will contain the following components:
+This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE Edge for Telco (formerly known as ATIP). The management cluster will contain the following components:
 - SUSE Linux Micro 6.0 Kernel (SL Micro 6.0)
 - RKE2
 - CNI plugins (e.g. Multus, Cilium)
@@ -110,7 +110,7 @@ $ cd telco-examples/mgmt-cluster/multi-node/eib
 
 ```bash
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file mgmt-cluster-multinode.yaml
 ```
 

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/rancher.sh
@@ -49,13 +49,13 @@ if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{
   done
 
   # Set password
-  curl -sk ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
 
   # Create a temporary API token (ttl=60 minutes)
   APITOKEN=$(curl -sk ${RANCHERHOSTNAME}/v3/token -H 'content-type: application/json' -H "Authorization: Bearer ${TOKEN}" -d '{"type":"token","description":"automation","ttl":3600000}' | jq -r .token)
 
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
 fi
 
 # Clean up the lock cm

--- a/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
@@ -27,47 +27,47 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.1
+        version: 302.0.0+up0.9.0
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.1
+        version: 2.10.1
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
       - name: rancher-turtles-chart
-        version: 0.3.2
+        version: 302.0.0+up0.14.1
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
@@ -75,10 +75,10 @@ kubernetes:
     repositories:
       - name: jetstack
         url: https://charts.jetstack.io
-      - name: rancher-charts
-        url: https://charts.rancher.io/
+      - name: rancher
+        url: https://charts.rancher.io
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge
+        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
     network:

--- a/telco-examples/mgmt-cluster/single-node/README.md
+++ b/telco-examples/mgmt-cluster/single-node/README.md
@@ -1,7 +1,7 @@
 
 # Management Cluster in a single-node setup
 
-This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE ATIP. The management cluster will contain the following components:
+This is an example of using Edge Image Builder (EIB) to generate a management cluster iso image for SUSE Edge for Telco (formerly known as ATIP). The management cluster will contain the following components:
 - SUSE Linux Micro 6.0 Kernel (SL Micro 6.0)
 - RKE2
 - CNI plugins (e.g. Multus, Cilium)
@@ -93,7 +93,7 @@ $ cd telco-examples/mgmt-cluster/single-node/eib
 
 ```bash
 $ sudo podman run --rm --privileged -it -v $PWD:/eib \
-registry.suse.com/edge/3.1/edge-image-builder:1.1.0 \
+registry.suse.com/edge/3.2/edge-image-builder:1.1.0 \
 build --definition-file mgmt-cluster-singlenode.yaml
 ```
 

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/files/rancher.sh
@@ -32,6 +32,7 @@ fi
 
 # Wait for rancher to be deployed
 while ! ${KUBECTL} wait --for condition=ready -n ${RANCHER_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name) --timeout=10s; do sleep 2 ; done
+until ${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher > /dev/null 2>&1; do sleep 10; done
 
 RANCHERBOOTSTRAPPASSWORD=$(${KUBECTL} get secret -n ${RANCHER_CHART_TARGETNAMESPACE} bootstrap-secret -o jsonpath='{.data.bootstrapPassword}' | base64 -d)
 RANCHERHOSTNAME=$(${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} rancher -o jsonpath='{.spec.rules[0].host}')
@@ -48,13 +49,13 @@ if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{
   done
 
   # Set password
-  curl -sk ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/users?action=changepassword -H 'content-type: application/json' -H "Authorization: Bearer $TOKEN" -d "{\"currentPassword\":\"${RANCHERBOOTSTRAPPASSWORD}\",\"newPassword\":\"${RANCHER_FINALPASSWORD}\"}"
 
   # Create a temporary API token (ttl=60 minutes)
   APITOKEN=$(curl -sk ${RANCHERHOSTNAME}/v3/token -H 'content-type: application/json' -H "Authorization: Bearer ${TOKEN}" -d '{"type":"token","description":"automation","ttl":3600000}' | jq -r .token)
 
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
-  curl -sk ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/server-url -H 'content-type: application/json' -H "Authorization: Bearer ${APITOKEN}" -X PUT -d "{\"name\":\"server-url\",\"value\":\"${RANCHERHOSTNAME}\"}"
+  curl -sk -L ${RANCHERHOSTNAME}/v3/settings/telemetry-opt -X PUT -H 'content-type: application/json' -H 'accept: application/json' -H "Authorization: Bearer ${APITOKEN}" -d '{"value":"out"}'
 fi
 
 # Clean up the lock cm

--- a/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
@@ -16,7 +16,7 @@ operatingSystem:
     - openssh-server-config-rootlogin
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}
 kubernetes:
-  version: v1.30.3+rke2r1
+  version: v1.31.3+rke2r1
   helm:
     charts:
       - name: cert-manager
@@ -27,47 +27,47 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn-crd
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: longhorn
-        version: 104.2.0+up1.7.1
-        repositoryName: rancher-charts
+        version: 105.1.0+up1.7.2
+        repositoryName: rancher
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
       - name: metal3-chart
-        version: 0.8.1
+        version: 302.0.0+up0.9.0
         repositoryName: suse-edge-charts
         targetNamespace: metal3-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: metal3.yaml
       - name: neuvector-crd
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: neuvector
-        version: 104.0.1+up2.7.9
-        repositoryName: rancher-charts
+        version: 105.0.0+up2.8.3
+        repositoryName: rancher
         targetNamespace: neuvector
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: neuvector.yaml
       - name: rancher
-        version: 2.9.1
+        version: 2.10.1
         repositoryName: rancher-prime
         targetNamespace: cattle-system
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
       - name: rancher-turtles-chart
-        version: 0.3.2
+        version: 302.0.0+up0.14.1
         repositoryName: suse-edge-charts
         targetNamespace: rancher-turtles-system
         createNamespace: true
@@ -75,9 +75,9 @@ kubernetes:
     repositories:
       - name: jetstack
         url: https://charts.jetstack.io
-      - name: rancher-charts
-        url: https://charts.rancher.io/
+      - name: rancher
+        url: https://charts.rancher.io
       - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.1
+        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime


### PR DESCRIPTION
This PR contains the following changes:
- 3.2 update version (mgtm-cluster and downstream-clusters) 
- fix rancher.sh script to avoid a race condition
- Modify the ATIP in the rest of the files (Basically all README)

NOTE: the aarch64 mgmt eib definition file should keep the Suse-edge upstream because it's a tech-preview and it will be released in 3.3 