### PR TITLE
fix to remove not-needed helm-charts in aarch64

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
@@ -79,7 +79,5 @@ kubernetes:
         url: https://charts.rancher.io/
       - name: suse-edge-upstream
         url: https://suse-edge.github.io/charts
-      - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime


### PR DESCRIPTION
- As we're offering ARM as a tech-preview we don't need the helm chart for releases because metal3 and turtles will use upstream chart by now
