### PR TITLE
fix to remove not-needed helm-charts in aarch64

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
@@ -79,7 +79,5 @@ kubernetes:
         url: https://charts.rancher.io/
       - name: suse-edge-upstream
         url: https://suse-edge.github.io/charts
-      - name: suse-edge-charts
-        url: oci://registry.suse.com/edge/3.2
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime


### PR DESCRIPTION
(cherry picked from commit 31260b6e67c96e8ed83f32e147b9511614f2ff27)