### PR TITLE
add overrides for prime images

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/config/server.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/config/server.yaml
@@ -3,4 +3,4 @@ cni:
   - cilium
 write-kubeconfig-mode: '0644'
 selinux: true
-token: foobar
+system-default-registry: registry.rancher.com

--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/longhorn.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/longhorn.yaml
@@ -1,0 +1,3 @@
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/neuvector.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/neuvector.yaml
@@ -12,3 +12,7 @@ k3s:
   enabled: true
 crdwebhook:
   enabled: false
+registry: "registry.rancher.com"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,6 @@
 hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
 bootstrapPassword: "foobar"
 replicas: 1
-global.cattle.psp.enabled: "false"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
@@ -38,6 +38,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: 303.0.7+up0.11.5
         repositoryName: suse-edge-charts

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/config/server.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/config/server.yaml
@@ -3,4 +3,4 @@ cni:
   - cilium
 write-kubeconfig-mode: '0644'
 selinux: true
-token: foobar
+system-default-registry: registry.rancher.com

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/longhorn.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/longhorn.yaml
@@ -1,0 +1,3 @@
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/neuvector.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/neuvector.yaml
@@ -12,3 +12,7 @@ k3s:
   enabled: true
 crdwebhook:
   enabled: false
+registry: "registry.rancher.com"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,6 @@
 hostname: ${MGMT_CLUSTER_IP}
 bootstrapPassword: "foobar"
 replicas: 1
-global.cattle.psp.enabled: "false"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
@@ -38,6 +38,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: 303.0.7+up0.11.5
         repositoryName: suse-edge-charts
@@ -131,3 +132,4 @@ embeddedArtifactRegistry:
     - name: registry.suse.com/rancher/hardened-sriov-network-operator:v1.5.0-build20250425
     - name: registry.suse.com/rancher/ip-address-manager:v1.9.4
     - name: registry.rancher.com/rancher/kubectl:v1.32.2
+    - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.9.5

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/config/server.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/config/server.yaml
@@ -3,4 +3,4 @@ cni:
   - cilium
 write-kubeconfig-mode: '0644'
 selinux: true
-token: foobar
+system-default-registry: registry.rancher.com

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/longhorn.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/longhorn.yaml
@@ -1,0 +1,3 @@
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/neuvector.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/neuvector.yaml
@@ -12,3 +12,7 @@ k3s:
   enabled: true
 crdwebhook:
   enabled: false
+registry: "registry.rancher.com"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,6 @@
 hostname: rancher-${INGRESS_VIP}.sslip.io
 bootstrapPassword: "foobar"
 replicas: 1
-global.cattle.psp.enabled: "false"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
@@ -38,6 +38,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: 303.0.7+up0.11.5
         repositoryName: suse-edge-charts

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/config/server.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/config/server.yaml
@@ -3,4 +3,4 @@ cni:
   - cilium
 write-kubeconfig-mode: '0644'
 selinux: true
-token: foobar
+system-default-registry: registry.rancher.com

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/longhorn.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/longhorn.yaml
@@ -1,0 +1,3 @@
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/neuvector.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/neuvector.yaml
@@ -12,3 +12,7 @@ k3s:
   enabled: true
 crdwebhook:
   enabled: false
+registry: "registry.rancher.com"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,6 @@
 hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
 bootstrapPassword: "foobar"
 replicas: 1
-global.cattle.psp.enabled: "false"
+global:
+  cattle:
+    systemDefaultRegistry: "registry.rancher.com"

--- a/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
@@ -38,6 +38,7 @@ kubernetes:
         targetNamespace: longhorn-system
         createNamespace: true
         installationNamespace: kube-system
+        valuesFile: longhorn.yaml
       - name: metal3
         version: 303.0.7+up0.11.5
         repositoryName: suse-edge-charts


### PR DESCRIPTION
Add overrides to use Prime registry images for the following components:
- Neuvector
- Rancher
- longhorn (new)
- rke2 (based on the server.yaml file)

Also add a modification with a missing airgap image due to the (rancher webhook disabled components)