### PR TITLE
added validation step of rancher api being ready before attemtping to…

### DIFF
--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/rancher.sh
@@ -41,6 +41,18 @@ RANCHERHOSTNAME=$(${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} ran
 if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{.value}') ]; then
   # Add the protocol
   RANCHERHOSTNAME="https://${RANCHERHOSTNAME}"
+
+  # Wait for Rancher API to be ready
+  while true; do
+    STATUS=$(curl -sk -o /dev/null -w '%{http_code}' ${RANCHERHOSTNAME}/v3-public)
+    if [ "$STATUS" -eq 200 ]; then
+      break
+    fi
+    sleep 10
+    echo "Waiting for Rancher API to be ready..."
+  done
+
+  # Now attempt to get the token
   TOKEN=""
   while [ -z "${TOKEN}" ]; do
     # Get token

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/files/rancher.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/files/rancher.sh
@@ -41,6 +41,18 @@ RANCHERHOSTNAME=$(${KUBECTL} get ingress -n ${RANCHER_CHART_TARGETNAMESPACE} ran
 if [ -z $(${KUBECTL} get settings.management.cattle.io first-login -ojsonpath='{.value}') ]; then
   # Add the protocol
   RANCHERHOSTNAME="https://${RANCHERHOSTNAME}"
+
+  # Wait for Rancher API to be ready
+  while true; do
+    STATUS=$(curl -sk -o /dev/null -w '%{http_code}' ${RANCHERHOSTNAME}/v3-public)
+    if [ "$STATUS" -eq 200 ]; then
+      break
+    fi
+    sleep 10
+    echo "Waiting for Rancher API to be ready..."
+  done
+
+  # Now attempt to get the token
   TOKEN=""
   while [ -z "${TOKEN}" ]; do
     # Get token


### PR DESCRIPTION
… get a token

When the `mgmt-stack-setup.service`  runs the `ranche.sh` script, I consistently run into this situation:
```
rancher.sh[41847]: ++ /var/lib/rancher/rke2/bin/kubectl get settings.management.cattle.io first-login '-ojsonpath={.value}'
rancher.sh[8917]: + '[' -z ']'
rancher.sh[8917]: + RANCHERHOSTNAME=https://rancher-10.140.1.24.sslip.io
rancher.sh[8917]: + TOKEN=
rancher.sh[8917]: + '[' -z '' ']'
rancher.sh[8917]: + sleep 2
rancher.sh[41982]: ++ curl -sk -X POST 'https://rancher-10.140.1.24.sslip.io/v3-public/localProviders/local?action=login' -H 'conten>
rancher.sh[41983]: ++ jq -r .token
rancher.sh[41983]: jq: parse error: Invalid numeric literal at line 1, column 7
rancher.sh[8917]: + TOKEN=
rancher.sh[8917]: + catch 5 1
rancher.sh[8917]: + '[' 5 '!=' 0 ']'
rancher.sh[8917]: + echo 'Error 5 occurred on 1'
rancher.sh[8917]: Error 5 occurred on 1
rancher.sh[8917]: + /var/lib/rancher/rke2/bin/kubectl delete configmap rancher-lock -n default
rancher.sh[42015]: configmap "rancher-lock" deleted
systemd[1]: mgmt-stack-setup.service: Control process exited, code=exited, status=5/NOTINSTALLED
systemd[1]: mgmt-stack-setup.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Setup Management stack components.
```

The `mgmt-stack-setup.service` stops before being able to run other scripts, like `metal3.sh` which also stops metal3 to be able to be assigned an IP to its LoadBalancer service.

While the `rancher.sh` script waits for the rancher pod to be in a running state before proceeding, it seems like the API need a little longer in order to be ready and respond with a proper JSON structure.

I added an extra step to the validations in `rancher.sh` script in order to also check for the `v3-public/` endpoint to return an HTTP code `200` before attempting to retrieve a token from it; this has consistently changed the behavior in a positive way in my tests:
```
rancher.sh[26890]: error: timed out waiting for the condition on pods/rancher-86969844cb-sc2vn
rancher.sh[27654]: error: timed out waiting for the condition on pods/rancher-86969844cb-sc2vn
rancher.sh[31694]: error: timed out waiting for the condition on pods/rancher-86969844cb-sc2vn
rancher.sh[37838]: pod/rancher-post-delete-pn9dj condition met
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[11756]: Waiting for Rancher API to be ready...
rancher.sh[45715]: {"baseType":"setting","created":"2025-07-28T13:49:45Z","createdTS":1753710585000,"creatorId":null,"customized":true,>
rancher.sh[45737]: {"baseType":"error","code":"NotFound","message":"settings.management.cattle.io \"telemetry-opt\" not found","status">
rancher.sh[45749]: configmap "rancher-lock" deleted
metal3.sh[46005]: Error from server (NotFound): configmaps "metal3-lock" not found
metal3.sh[46052]: configmap/metal3-lock created```
```

In this way `mgmt-stack-setup.service` is able to complete the `rancher.sh` actions and proceed to execute the remaining scripts successfully.

I have validated this only with multi and single mgmt cluster control planes on x86_64 in a fully internet connected environments via L3, no airgap or proxy.