### PR TITLE
restart rke2-server when stuck ready state condition

### DIFF
--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/check-node-ready-state.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/check-node-ready-state.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BASEDIR="$(dirname "$0")"
+source ${BASEDIR}/basic-setup.sh
+
+# Check if the script is running as root
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root" 1>&2
+  exit 1
+fi
+
+# Function to wait for ${KUBECTL} get nodes to succeed (API server readiness)
+wait_for_api_server() {
+  local timeout=300  # 5 minutes
+  local start_time=$(date +%s)
+  while true; do
+    if ${KUBECTL} get nodes &> /dev/null; then
+      echo "API server is ready."
+      return 0
+    fi
+    local current_time=$(date +%s)
+    if [ $((current_time - start_time)) -ge $timeout ]; then
+      echo "Timeout waiting for API server."
+      exit 1
+    fi
+    sleep 10
+  done
+}
+
+# Wait for API server to be ready
+wait_for_api_server
+
+NODE_NAME="$(hostname)"
+#NODE_NAME="edge-mgmt-cplane-1"
+LAST_RESTART_TIME=0
+COOLDOWN=300  # 5 minutes in seconds
+
+while true; do
+  CURRENT_TIME=$(date +%s)
+  
+  # Extract node conditions using ${KUBECTL}
+  READY_STATUS=$(${KUBECTL} get node $NODE_NAME -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+  NET_UNAVAILABLE_STATUS=$(${KUBECTL} get node $NODE_NAME -o jsonpath='{.status.conditions[?(@.type=="NetworkUnavailable")].status}')
+  
+  # Check if the node is ready
+  if [ "$READY_STATUS" == "True" ]; then
+    echo "$(date): Node is ready. Exiting."
+    exit 0
+
+  # Check if all required conditions are met
+  elif [ "$READY_STATUS" == "False" ] && [ "$NET_UNAVAILABLE_STATUS" == "False" ]; then
+    # Check if enough time has passed since the last restart
+    if [ $((CURRENT_TIME - LAST_RESTART_TIME)) -gt $COOLDOWN ]; then
+      echo "$(date): Detected stuck state: NotReady with NetworkUnavailable=False and CNIIsUp. Restarting rke2-server."
+      systemctl restart rke2-server
+      LAST_RESTART_TIME=$CURRENT_TIME
+      exit 0
+    else
+      echo "$(date): Stuck state detected, but within cooldown period. Waiting."
+    fi
+  else
+    echo "$(date): Node is not in stuck state."
+  fi
+  
+  # Sleep for 10 seconds before checking again
+  sleep 10
+done

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/mgmt-stack-setup.service
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/mgmt-stack-setup.service
@@ -14,12 +14,14 @@ TimeoutStartSec=1800
 
 ExecStartPre=/bin/sh -c "echo 'Setting up Management components...'"
 # Scripts are executed in StartPre because Start can only run a single on
+ExecStartPre=/opt/mgmt/bin/check-node-ready-state.sh
 ExecStartPre=/opt/mgmt/bin/rancher.sh
 ExecStartPre=/opt/mgmt/bin/metal3.sh
 ExecStart=/bin/sh -c "echo 'Finished setting up Management components'"
 RemainAfterExit=yes
 KillMode=process
 # Disable & delete everything
+ExecStartPost=rm -f /opt/mgmt/bin/check-node-ready-state.sh
 ExecStartPost=rm -f /opt/mgmt/bin/rancher.sh
 ExecStartPost=rm -f /opt/mgmt/bin/metal3.sh
 ExecStartPost=rm -f /opt/mgmt/bin/basic-setup.sh

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/scripts/99-mgmt-setup.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/scripts/99-mgmt-setup.sh
@@ -2,7 +2,7 @@
 
 # Copy the scripts from combustion to the final location
 mkdir -p /opt/mgmt/bin/
-for script in basic-setup.sh rancher.sh metal3.sh; do
+for script in basic-setup.sh rancher.sh metal3.sh check-node-ready-state.sh; do
 	cp ${script} /opt/mgmt/bin/
 done
 


### PR DESCRIPTION
When installing an edge management cluster I consistently run into this situation on all control plane nodes:
```
Conditions:
  Type                 Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
  ----                 ------  -----------------                 ------------------                ------                       -------
  NetworkUnavailable   False   Sat, 26 Jul 2025 21:43:12 +0000   Sat, 26 Jul 2025 21:43:12 +0000   CiliumIsUp                   Cilium is running on this node
  EtcdIsVoter          True    Sat, 26 Jul 2025 21:42:43 +0000   Sat, 26 Jul 2025 21:42:43 +0000   MemberNotLearner             Node is a voting member of the etcd cluster
  MemoryPressure       False   Sat, 26 Jul 2025 21:42:36 +0000   Sat, 26 Jul 2025 21:42:26 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
  DiskPressure         False   Sat, 26 Jul 2025 21:42:36 +0000   Sat, 26 Jul 2025 21:42:26 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
  PIDPressure          False   Sat, 26 Jul 2025 21:42:36 +0000   Sat, 26 Jul 2025 21:42:26 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
  Ready                False   Sat, 26 Jul 2025 21:42:36 +0000   Sat, 26 Jul 2025 21:42:26 +0000   KubeletNotReady              container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
```

The node should pick up that `NetworkUnavailable=False` which means the CNI is up and running and the node should switch to a Ready state, allowing for install to proceed.
Such situation leaves most pods in `Pending` state because the node is not Ready:
```
NAMESPACE     NAME                                                    READY   STATUS      RESTARTS      AGE
kube-system   cilium-kgskj                                            1/1     Running     0             37s
kube-system   cilium-operator-75f4697ff7-8s4zk                        0/1     Pending     0             37s
kube-system   cilium-operator-75f4697ff7-xwrrl                        1/1     Running     0             37s
kube-system   cloud-controller-manager-edge-mgmt-cplane-1             1/1     Running     0             51s
kube-system   etcd-edge-mgmt-cplane-1                                 1/1     Running     0             55s
kube-system   helm-install-cert-manager-qcqc2                         0/1     Pending     0             46s
kube-system   helm-install-endpoint-copier-operator-r658g             0/1     Pending     0             46s
kube-system   helm-install-longhorn-8dsth                             0/1     Pending     0             46s
kube-system   helm-install-longhorn-crd-9gwpj                         0/1     Pending     0             46s
kube-system   helm-install-metal3-6khz5                               0/1     Pending     0             45s
kube-system   helm-install-metallb-p4jc5                              0/1     Pending     0             45s
kube-system   helm-install-neuvector-4tclj                            0/1     Pending     0             44s
kube-system   helm-install-neuvector-crd-xbm6q                        0/1     Pending     0             44s
kube-system   helm-install-rancher-59qrf                              0/1     Pending     0             44s
kube-system   helm-install-rancher-turtles-kf5vn                      0/1     Pending     0             44s
kube-system   helm-install-rke2-cilium-mv6bk                          0/1     Completed   0             46s
kube-system   helm-install-rke2-coredns-4k8t8                         0/1     Completed   0             46s
kube-system   helm-install-rke2-ingress-nginx-xrpg7                   0/1     Pending     0             44s
kube-system   helm-install-rke2-metrics-server-jwmwt                  0/1     Pending     0             46s
kube-system   helm-install-rke2-multus-927mg                          0/1     Completed   0             46s
kube-system   helm-install-rke2-runtimeclasses-8b55q                  0/1     Pending     0             46s
kube-system   helm-install-rke2-snapshot-controller-crd-7kkf7         0/1     Pending     0             46s
kube-system   helm-install-rke2-snapshot-controller-v59rh             0/1     Pending     0             46s
kube-system   kube-apiserver-edge-mgmt-cplane-1                       1/1     Running     0             55s
kube-system   kube-controller-manager-edge-mgmt-cplane-1              1/1     Running     0             53s
kube-system   kube-proxy-edge-mgmt-cplane-1                           1/1     Running     0             55s
kube-system   kube-scheduler-edge-mgmt-cplane-1                       1/1     Running     0             53s
kube-system   rke2-coredns-rke2-coredns-9fbf6dcbc-7skbq               0/1     Pending     0             37s
kube-system   rke2-coredns-rke2-coredns-autoscaler-6574d559f6-kj57l   0/1     Pending     0             37s
kube-system   rke2-multus-6v9nl                                       1/1     Running     2 (26s ago)   38s
```

While this situation could be related to [rke2 issue #8356](https://github.com/rancher/rke2/issues/8356), I have also found reference to similar or identical situations outside of SL Micro and SUSE stack in general.

[containerd issue #10290](https://github.com/containerd/containerd/discussions/10290)

[arch linux documentation](https://wiki.archlinux.org/title/Kubernetes) installing kubernetes with `kubeadm` and Cilium recommends to "Restart containerd.service and kubelet.service" at the end of step "4. Join cluster" as a mitigation for a situation identical to the one described here.

The above list is not intended to be exhaustive, it just represents this issue to exists outside of the domain of our specific solutions.

While in this case I was using Cilium, the same occurs also using Calico.

The only workaround I found is to restart the `rke2-server.service` or restart the node altogether.

In order to mitigate this situation (which in my tests is systematic for all control plane nodes), I have added a script to the `mgmt-stack-setup.service` to catch the described situation and restart the `rke2-server.service` service if it happens.


