### PR TITLE
fixed inconsistent example that makes rancher install fail

### DIFF
--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,4 @@
-hostname: ${MGMT_CLUSTER_IP}
+hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
 bootstrapPassword: "foobar"
 replicas: 1
 global:


### PR DESCRIPTION
Following instructions for air-gap install of the mgmt-cluster:
```
You need to modify the ${MGMT_CLUSTER_IP} with the Node IP in the following files:

kubernetes/helm/values/metal3.yaml

kubernetes/helm/values/rancher.yaml
```

This takes to Rancher never completing installing:
```bash
$ k -n kube-system logs helm-install-rancher-t9f22

+ echo 'Installing helm chart'
Deleted
+ helm install --namespace cattle-system --create-namespace --version 2.11.2 rancher /tmp/rancher.tgz --values /config/values-0-000-HelmChart-ValuesContent.yaml
Error: INSTALLATION FAILED: 1 error occurred:
  * Ingress.networking.k8s.io "rancher" is invalid: spec.rules[0].host: Invalid value: "10.150.1.11": must be a DNS name, not an IP address

+ exit
```

The reason for this is that the example file `kubernetes/helm/values/rancher.yaml` is inconsistent with other scenarios in the `atip` repo, where the `rancher.yaml` file looks like this:
```yaml
hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
bootstrapPassword: "foobar"
replicas: 1
global:
  cattle:
    systemDefaultRegistry: "registry.rancher.com"
```

While in the air-gap structure the `kubernetes/helm/values/rancher.yaml` file looks like this:
```yaml
hostname: ${MGMT_CLUSTER_IP}
bootstrapPassword: "foobar"
replicas: 1
global:
  cattle:
    systemDefaultRegistry: "registry.rancher.com"
```

If instructions are followed, the user ends up having just the ip address in the `hostname` value while Rancher requires an FQDN to properly install because the creation of the ingress object fails to be created:
```
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + /var/lib/rancher/rke2/bin/kubectl get ingress -n cattle-system rancher
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + sleep 10
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + /var/lib/rancher/rke2/bin/kubectl get ingress -n cattle-system rancher
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + sleep 10
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + /var/lib/rancher/rke2/bin/kubectl get ingress -n cattle-system rancher
edge-mgmt-airgap-cplane-1-ma21 rancher.sh[11313]: + sleep 10
```