### PR TITLE
Fix indentation and multiple initializers

### DIFF
--- a/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
@@ -82,16 +82,16 @@ kubernetes:
         url: oci://registry.suse.com/edge/charts
       - name: rancher-prime
         url: https://charts.rancher.com/server-charts/prime
-    network:
-      apiHost: ${API_HOST}
-      apiVIP: ${API_VIP}
-    nodes:
-      - hostname: mgmt-cluster1
-        initializer: true
-        type: server
-      - hostname: mgmt-cluster2
-        initializer: true
-        type: server
-      - hostname: mgmt-cluster3
-        initializer: true
-        type: server
+  network:
+    apiHost: ${API_HOST}
+    apiVIP: ${API_VIP}
+  nodes:
+    - hostname: mgmt-cluster1
+      initializer: true
+      type: server
+    - hostname: mgmt-cluster2
+      initializer: true
+      type: server
+    - hostname: mgmt-cluster3
+      initializer: true
+      type: server

--- a/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
@@ -90,8 +90,6 @@ kubernetes:
       initializer: true
       type: server
     - hostname: mgmt-cluster2
-      initializer: true
       type: server
     - hostname: mgmt-cluster3
-      initializer: true
       type: server


### PR DESCRIPTION
The `mgmt-cluster-multinode.yaml` file has 2 errors:

1. the network and nodes sections are incorrectly aligned with the helm charts structure and this makes building with EIB fail
2. there are multiple initializer nodes which again is not a working configuration stopping the EIB building process