### PR TITLE
Match the latest name for the ironic ConfigMap

### DIFF
--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
@@ -29,7 +29,7 @@ fi
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
 # Get the ironic IP
-IRONICIP=$(${KUBECTL} get cm -n ${METAL3_CHART_TARGETNAMESPACE} ironic-bmo -o jsonpath='{.data.IRONIC_IP}')
+IRONICIP=$(${KUBECTL} get cm -n ${METAL3_CHART_TARGETNAMESPACE} ironic -o jsonpath='{.data.IRONIC_IP}')
 
 # If LoadBalancer, use metallb, else it is NodePort
 if [ $(${KUBECTL} get svc -n ${METAL3_CHART_TARGETNAMESPACE} metal3-metal3-ironic -o jsonpath='{.spec.type}') == "LoadBalancer" ]; then


### PR DESCRIPTION
The name of the ironic ConfigMap will change from `ironic-bmo` to `ironic` in 3.4, update the MetalLB script.