### PR TITLE
Deal with possible missed notifications for CNI directory

### DIFF
--- a/telco-examples/edge-clusters/aarch64/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/edge-clusters/aarch64/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/edge-clusters/airgap/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/edge-clusters/airgap/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/edge-clusters/dhcp-less/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/edge-clusters/dhcp-less/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/edge-clusters/dhcp/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/edge-clusters/dhcp/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/mgmt-cluster/aarch64/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/mgmt-cluster/aarch64/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/mgmt-cluster/airgap/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/mgmt-cluster/airgap/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/scripts/02-tmpfs-cni.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/scripts/02-tmpfs-cni.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p /etc/cni
+mount -t tmpfs -o mode=0700,size=5M tmpfs /etc/cni
+echo "tmpfs /etc/cni tmpfs defaults,size=5M,mode=0700 0 0" >> /etc/fstab


### PR DESCRIPTION
On RKE2/K3s 1.31 and 1.32 versions, the directory /etc/cni being used to store CNI configurations may not trigger a notification of the files being written there to containerd due to certain conditions related to overlayfs (see the https://github.com/rancher/rke2/issues/8356%5B#8356 RKE2 issue]). This in turn results in the deployment of RKE2/K3s to get stuck waiting for the CNI to start, and the RKE2/K3s nodes to stay in NotReady state.

Add a custom script in the eib directory structure to workaround the above issue that affects the 3.4 release.