### PR TITLE
add missing kernel args for telco and performance settings

### DIFF
--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -125,7 +125,7 @@ spec:
             - iommu=pt
             - idle=poll
             - mce=off
-            - hugepagesz=1G hugepages=4
+            - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
             - irqaffinity=${NON_ISOLATED_CPU_CORES}
@@ -139,6 +139,11 @@ spec:
             - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -218,7 +218,7 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
+            - irqaffinity=${NON_ISOLATED_CPU_CORES}
             - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
             - nohz_full=${ISOLATED_CPU_CORES}
             - rcu_nocbs=${ISOLATED_CPU_CORES}
@@ -226,9 +226,14 @@ spec:
             - nosoftlockup
             - nowatchdog
             - nohz=on
-            - nmi_watchdog=0 
+            - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -133,7 +133,7 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
+            - irqaffinity=${NON_ISOLATED_CPU_CORES}
             - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
             - nohz_full=${ISOLATED_CPU_CORES}
             - rcu_nocbs=${ISOLATED_CPU_CORES}
@@ -141,9 +141,14 @@ spec:
             - nosoftlockup
             - nowatchdog
             - nohz=on
-            - nmi_watchdog=0 
+            - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -214,7 +214,7 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
+            - irqaffinity=${NON_ISOLATED_CPU_CORES}
             - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
             - nohz_full=${ISOLATED_CPU_CORES}
             - rcu_nocbs=${ISOLATED_CPU_CORES}
@@ -222,9 +222,14 @@ spec:
             - nosoftlockup
             - nowatchdog
             - nohz=on
-            - nmi_watchdog=0 
+            - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -133,7 +133,7 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
+            - irqaffinity=${NON_ISOLATED_CPU_CORES}
             - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
             - nohz_full=${ISOLATED_CPU_CORES}
             - rcu_nocbs=${ISOLATED_CPU_CORES}
@@ -141,9 +141,14 @@ spec:
             - nosoftlockup
             - nowatchdog
             - nohz=on
-            - nmi_watchdog=0 
+            - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -214,7 +214,7 @@ spec:
             - hugepagesz=1G hugepages=40
             - hugepagesz=2M hugepages=0
             - default_hugepagesz=1G
-            - irqaffinity=${NON-ISOLATED_CPU_CORES}
+            - irqaffinity=${NON_ISOLATED_CPU_CORES}
             - isolcpus=domain,nohz,managed_irq,${ISOLATED_CPU_CORES}
             - nohz_full=${ISOLATED_CPU_CORES}
             - rcu_nocbs=${ISOLATED_CPU_CORES}
@@ -222,9 +222,14 @@ spec:
             - nosoftlockup
             - nowatchdog
             - nohz=on
-            - nmi_watchdog=0 
+            - nmi_watchdog=0
             - skew_tick=1
             - quiet
+            - rcupdate.rcu_cpu_stall_suppress=1
+            - rcupdate.rcu_expedited=1
+            - rcupdate.rcu_normal_after_boot=1
+            - rcupdate.rcu_task_stall_timeout=0
+            - rcutree.kthread_prio=99
         systemd:
           units:
             - name: rke2-preinstall.service


### PR DESCRIPTION
add missing params for kernel args in telco examples which enables the performance testing to get low latency values