### PR TITLE
Align with rancher-turtles-providers chart

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/aarch64/eib/custom/files/metal3.sh
@@ -28,23 +28,6 @@ fi
 # Wait for metal3
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
-# If rancher is deployed
-if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
-  cat <<-EOF | ${KUBECTL} apply -f -
-	apiVersion: management.cattle.io/v3
-	kind: Feature
-	metadata:
-	  name: embedded-cluster-api
-	spec:
-	  value: false
-	EOF
-
-  # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-  ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
-fi
-
 # Clean up the lock cm
 
 ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}

--- a/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/mgmt-cluster-arm-singlenode.yaml
@@ -61,10 +61,10 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
-      - name: rancher-turtles
-        version: 304.0.6+up0.24.0
+      - name: rancher-turtles-providers
+        version: 305.0.4+up0.25.1
         repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
+        targetNamespace: cattle-turtles-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:

--- a/telco-examples/mgmt-cluster/airgap/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/airgap/eib/custom/files/metal3.sh
@@ -28,23 +28,6 @@ fi
 # Wait for metal3
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
-# If rancher is deployed
-if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
-  cat <<-EOF | ${KUBECTL} apply -f -
-	apiVersion: management.cattle.io/v3
-	kind: Feature
-	metadata:
-	  name: embedded-cluster-api
-	spec:
-	  value: false
-	EOF
-
-  # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-  ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
-fi
-
 # Clean up the lock cm
 
 ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}

--- a/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
@@ -61,17 +61,10 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
-      - name: rancher-turtles
-        version: 304.0.6+up0.24.0
+      - name: rancher-turtles-providers
+        version: 305.0.4+up0.25.1
         repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
-        createNamespace: true
-        installationNamespace: kube-system
-        valuesFile: turtles.yaml
-      - name: rancher-turtles-airgap-resources
-        version: 304.0.6+up0.24.0
-        repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
+        targetNamespace: cattle-turtles-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:

--- a/telco-examples/mgmt-cluster/dual-stack/single-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/dual-stack/single-node/eib/custom/files/metal3.sh
@@ -28,23 +28,6 @@ fi
 # Wait for metal3
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
-# If rancher is deployed
-if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
-  cat <<-EOF | ${KUBECTL} apply -f -
-	apiVersion: management.cattle.io/v3
-	kind: Feature
-	metadata:
-	  name: embedded-cluster-api
-	spec:
-	  value: false
-	EOF
-
-  # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-  ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
-fi
-
 # Clean up the lock cm
 
 ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}

--- a/telco-examples/mgmt-cluster/dual-stack/single-node/eib/mgmt-cluster-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/dual-stack/single-node/eib/mgmt-cluster-singlenode.yaml
@@ -61,10 +61,10 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
-      - name: rancher-turtles
-        version: 304.0.6+up0.24.0
+      - name: rancher-turtles-providers
+        version: 305.0.4+up0.25.1
         repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
+        targetNamespace: cattle-turtles-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:

--- a/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/multi-node/eib/custom/files/metal3.sh
@@ -66,23 +66,6 @@ if [ $(${KUBECTL} get svc -n ${METAL3_CHART_TARGETNAMESPACE} metal3-metal3-ironi
 	EOF
 fi
 
-# If rancher is deployed
-if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
-  cat <<-EOF | ${KUBECTL} apply -f -
-	apiVersion: management.cattle.io/v3
-	kind: Feature
-	metadata:
-	  name: embedded-cluster-api
-	spec:
-	  value: false
-	EOF
-
-  # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-  ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
-fi
-
 # Clean up the lock cm
 
 ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}

--- a/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/mgmt-cluster-multinode.yaml
@@ -61,10 +61,10 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
-      - name: rancher-turtles
-        version: 304.0.6+up0.24.0
+      - name: rancher-turtles-providers
+        version: 305.0.4+up0.25.1
         repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
+        targetNamespace: cattle-turtles-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:

--- a/telco-examples/mgmt-cluster/single-node/eib/custom/files/metal3.sh
+++ b/telco-examples/mgmt-cluster/single-node/eib/custom/files/metal3.sh
@@ -28,23 +28,6 @@ fi
 # Wait for metal3
 while ! ${KUBECTL} wait --for condition=ready -n ${METAL3_CHART_TARGETNAMESPACE} $(${KUBECTL} get pods -n ${METAL3_CHART_TARGETNAMESPACE} -l app.kubernetes.io/name=metal3-ironic -o name) --timeout=10s; do sleep 2 ; done
 
-# If rancher is deployed
-if [ $(${KUBECTL} get pods -n ${RANCHER_CHART_TARGETNAMESPACE} -l app=rancher -o name | wc -l) -ge 1 ]; then
-  cat <<-EOF | ${KUBECTL} apply -f -
-	apiVersion: management.cattle.io/v3
-	kind: Feature
-	metadata:
-	  name: embedded-cluster-api
-	spec:
-	  value: false
-	EOF
-
-  # Disable Rancher webhooks for CAPI
-  ${KUBECTL} delete --ignore-not-found=true mutatingwebhookconfiguration.admissionregistration.k8s.io mutating-webhook-configuration
-  ${KUBECTL} delete --ignore-not-found=true validatingwebhookconfigurations.admissionregistration.k8s.io validating-webhook-configuration
-  ${KUBECTL} wait --for=delete namespace/cattle-provisioning-capi-system --timeout=300s
-fi
-
 # Clean up the lock cm
 
 ${KUBECTL} delete configmap ${METAL3LOCKCMNAME} -n ${METAL3LOCKNAMESPACE}

--- a/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/mgmt-cluster-singlenode.yaml
@@ -61,10 +61,10 @@ kubernetes:
         createNamespace: true
         installationNamespace: kube-system
         valuesFile: rancher.yaml
-      - name: rancher-turtles
-        version: 304.0.6+up0.24.0
+      - name: rancher-turtles-providers
+        version: 305.0.4+up0.25.1
         repositoryName: suse-edge-charts
-        targetNamespace: rancher-turtles-system
+        targetNamespace: cattle-turtles-system
         createNamespace: true
         installationNamespace: kube-system
     repositories:


### PR DESCRIPTION
This new chart replaces the previous rancher-turtles wrapper chart to align with the upstream turtles direction now that the turtles chart is integrated into Rancher 2.13

We no longer need the airgap-resources chart because the new providers chart creates the airgap resources by default