### PR TITLE
edge-1709 LB Exclusion

### DIFF
--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -40,6 +40,8 @@ kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -38,6 +38,8 @@ kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -40,6 +40,8 @@ kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -38,6 +38,8 @@ kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Updated RKE2ControlPlanes definitions with load balancer exclusion annotations on multi-node clusters to address edge-1709