### PR TITLE
Update package list in edge cluster YAML files with detailed category…

### DIFF
--- a/telco-examples/edge-clusters/aarch64/eib/telco-edge-cluster-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/eib/telco-edge-cluster-aarch64.yaml
@@ -20,13 +20,18 @@ operatingSystem:
   packages:
     packageList:
       - policycoreutils-python-utils
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
-      - open-iscsi
-      - tuned
-      - cpupower
-      - openssh-server-config-rootlogin
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - openssh-server-config-rootlogin # Non Telco specific (allows password-based root user ssh) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}

--- a/telco-examples/edge-clusters/airgap/eib/telco-edge-airgap-cluster.yaml
+++ b/telco-examples/edge-clusters/airgap/eib/telco-edge-airgap-cluster.yaml
@@ -21,13 +21,18 @@ operatingSystem:
       encryptedPassword: ${ROOT_PASSWORD}
   packages:
     packageList:
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
-      - open-iscsi
-      - tuned
-      - cpupower
-      - openssh-server-config-rootlogin
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - openssh-server-config-rootlogin # Non Telco specific (allows password-based root user ssh) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}

--- a/telco-examples/edge-clusters/dhcp-less/eib/telco-edge-cluster.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/eib/telco-edge-cluster.yaml
@@ -19,13 +19,18 @@ operatingSystem:
       encryptedPassword: ${ROOT_PASSWORD}
   packages:
     packageList:
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
-      - open-iscsi
-      - tuned
-      - cpupower
-      - openssh-server-config-rootlogin
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - openssh-server-config-rootlogin # Non Telco specific (allows password-based root user ssh) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}

--- a/telco-examples/edge-clusters/dhcp/eib/telco-edge-cluster.yaml
+++ b/telco-examples/edge-clusters/dhcp/eib/telco-edge-cluster.yaml
@@ -21,13 +21,18 @@ operatingSystem:
       encryptedPassword: ${ROOT_PASSWORD}
   packages:
     packageList:
-      - jq
-      - dpdk
-      - dpdk-tools
-      - libdpdk-25
-      - pf-bb-config
-      - open-iscsi
-      - tuned
-      - cpupower
-      - openssh-server-config-rootlogin
+      - jq            # Non Telco specific - category: testing/utils
+      - dpdk          # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - dpdk-tools    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: testing/utils
+      - libdpdk-25    # TelCo Core-Network UserPlane (5G UPF) & RAN UserPlane (gNB: DU & CU-UP) - category: runtime
+      - pf-bb-config  # TelCo RAN (gNB: DU) - category: config.
+      - open-iscsi    # Non Telco specific (required by SUSE Storage/Longhorn) - category: runtime
+      - tuned         # Non Telco specific (linux tuning) - category: config.
+      - cpupower      # Non Telco specific (linux tuning - CPU power related settings) - category: config.
+      - rt-tests      # Non Telco specific (RT scheduler-latency testing) - category: testing/utils
+      - openssh-server-config-rootlogin # Non Telco specific (allows password-based root user ssh) - category: testing/utils
+      - linuxptp      # TelCo RAN; time sync (gNB: DU) - category: runtime
+      - synce4l       # TelCo RAN; time sync (gNN: DU) - category: runtime
+      - pciutils      # Non Telco specific (provides "lspci" command) - category: testing/utils
+      - numactl       # Non Telco specific (provides "numatcl" command) - category: testing/utils
     sccRegistrationCode: ${SCC_REGISTRATION_CODE}


### PR DESCRIPTION
This pull request enhances the documentation and clarity of the `packageList` sections in several telco edge cluster YAML configuration files. It adds descriptive comments to each package, explaining its purpose and categorizing it (e.g., runtime, config, testing/utils). Additionally, a few new utility and testing packages are included for better system support and diagnostics.

**Documentation and clarity improvements:**

* Added descriptive comments for each package in the `packageList` within the following files, clarifying the role and category of each package:
  - `telco-edge-cluster-aarch64.yaml`
  - `telco-edge-airgap-cluster.yaml`
  - `telco-edge-cluster.yaml`
  - `telco-edge-cluster.yaml` (DHCP version)

**Package additions:**

* Added several utility and testing packages to the `packageList`, including `rt-tests`, `linuxptp`, `synce4l`, `pciutils`, and `numactl`, to improve system diagnostics, testing, and time synchronization capabilities. 