### PR TITLE
sctp kernel module to be loaded at bootup in downstream clusters' nodes

### DIFF
--- a/telco-examples/edge-clusters/aarch64/eib/os-files/etc/modules-load.d/sctp.conf
+++ b/telco-examples/edge-clusters/aarch64/eib/os-files/etc/modules-load.d/sctp.conf
@@ -1,0 +1,2 @@
+# Request "systemd-modules-load.service" to load sctp module at boot time
+sctp

--- a/telco-examples/edge-clusters/airgap/eib/os-files/etc/modules-load.d/sctp.conf
+++ b/telco-examples/edge-clusters/airgap/eib/os-files/etc/modules-load.d/sctp.conf
@@ -1,0 +1,2 @@
+# Request "systemd-modules-load.service" to load sctp module at boot time
+sctp

--- a/telco-examples/edge-clusters/dhcp-less/eib/os-files/etc/modules-load.d/sctp.conf
+++ b/telco-examples/edge-clusters/dhcp-less/eib/os-files/etc/modules-load.d/sctp.conf
@@ -1,0 +1,2 @@
+# Request "systemd-modules-load.service" to load sctp module at boot time
+sctp

--- a/telco-examples/edge-clusters/dhcp/eib/os-files/etc/modules-load.d/sctp.conf
+++ b/telco-examples/edge-clusters/dhcp/eib/os-files/etc/modules-load.d/sctp.conf
@@ -1,0 +1,2 @@
+# Request "systemd-modules-load.service" to load sctp module at boot time
+sctp


### PR DESCRIPTION
File` eib/os-files/etc/modules-load.d/sctp.conf` added to all EIB folders for downstream clusters with the following content:

```
# Request "systemd-modules-load.service" to load sctp module at boot time
sctp
```