### PR TITLE
Migrate examples to v1beta2

### DIFF
--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: test-cluster-minimal
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
     kind: RKE2ControlPlane
     name: test-cluster-minimal
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: test-cluster-minimal
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: test-cluster-minimal
@@ -40,10 +39,11 @@ metadata:
   name: test-cluster-minimal
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: test-cluster-minimal-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: test-cluster-minimal-controlplane
   replicas: 1
   agentConfig:
     format: ignition
@@ -72,11 +72,11 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: test-cluster-minimal-controlplane
@@ -95,7 +95,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco-arm.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: test-cluster-minimal-controlplane-template
@@ -104,9 +104,9 @@ spec:
   clusterName: test-cluster-minimal
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: test-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
     kind: RKE2ControlPlane
     name: test-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: test-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: test-cluster
@@ -40,16 +39,17 @@ metadata:
   name: test-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: test-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: test-cluster-controlplane
   replicas: 1
   serverConfig:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -210,11 +210,11 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: test-cluster-controlplane
@@ -233,7 +233,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco-arm.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: test-cluster-controlplane-template
@@ -242,9 +242,9 @@ spec:
   clusterName: test-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -20,7 +20,7 @@ data:
   username: ${REGISTRY_USERNAME}
   password: ${REGISTRY_PASSWORD}
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -31,20 +31,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -55,16 +55,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -76,27 +77,27 @@ spec:
     mirrors:
       docker.io:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+        - "${PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.suse.com:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+        - "${PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.suse.de:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+        - "${PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.opensuse.org:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+        - "${PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
       registry.rancher.com:
         endpoint:
-          - "${PRIVATE_REGISTRY_URL}"
+        - "${PRIVATE_REGISTRY_URL}"
         rewrite:
           "^(.*)$": "mirror/$1"
     configs:
@@ -117,7 +118,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     airGapped: true       # Airgap true to enable airgap mode
     format: ignition
@@ -322,10 +323,10 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -344,7 +345,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -353,9 +354,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -1,203 +1,202 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: example-clusterclass
   namespace: emea-spa
 spec:
   variables:
-    - name: controlPlaneMachineTemplate
-      required: true
-      schema:
-        openAPIV3Schema:
+  - name: controlPlaneMachineTemplate
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: string
+  - name: controlPlaneEndpointHost
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: string
+  - name: tlsSan
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
           type: string
-    - name: controlPlaneEndpointHost
-      required: true
-      schema:
-        openAPIV3Schema:
-          type: string
-    - name: tlsSan
-      required: true
-      schema:
-        openAPIV3Schema:
-          type: array
-          items:
-            type: string
   infrastructure:
-    ref:
+    templateRef:
       kind: Metal3ClusterTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       name: example-cluster-template
   controlPlane:
-    ref:
+    templateRef:
       kind: RKE2ControlPlaneTemplate
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       name: example-controlplane
   patches:
-    - name: setControlPlaneMachineTemplate
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/infrastructureRef/name"
-              valueFrom:
-                variable: controlPlaneMachineTemplate
-    - name: setControlPlaneEndpoint
-      definitions:
-        - selector:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: Metal3ClusterTemplate
-            matchResources:
-              infrastructureCluster: true  # Added to select InfraCluster
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/controlPlaneEndpoint/host"
-              valueFrom:
-                variable: controlPlaneEndpointHost
-    - name: setRegistrationAddress
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true  # Added to select ControlPlane
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/registrationAddress"
-              valueFrom:
-                variable: controlPlaneEndpointHost
-    - name: setTlsSan
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true  # Added to select ControlPlane
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/serverConfig/tlsSan"
-              valueFrom:
-                variable: tlsSan
-    - name: updateAdditionalUserData
-      definitions:
-        - selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-            kind: RKE2ControlPlaneTemplate
-            matchResources:
-              controlPlane: true
-          jsonPatches:
-            - op: replace
-              path: "/spec/template/spec/agentConfig/additionalUserData"
-              valueFrom:
-                template: |
-                  config: |
-                    variant: fcos
-                    version: 1.4.0
-                    storage:
-                      files:
-                        - path: /var/lib/rancher/rke2/server/manifests/endpoint-copier-operator.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: helm.cattle.io/v1
-                              kind: HelmChart
-                              metadata:
-                                name: endpoint-copier-operator
-                                namespace: kube-system
-                              spec:
-                                chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
-                                targetNamespace: endpoint-copier-operator
-                                version: 305.0.1+up0.3.0
-                                createNamespace: true
-                        - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: helm.cattle.io/v1
-                              kind: HelmChart
-                              metadata:
-                                name: metallb
-                                namespace: kube-system
-                              spec:
-                                chart: oci://registry.suse.com/edge/charts/metallb
-                                targetNamespace: metallb-system
-                                version: 305.0.1+up0.15.2
-                                createNamespace: true
-                        - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: metallb.io/v1beta1
-                              kind: IPAddressPool
-                              metadata:
-                                name: kubernetes-vip-ip-pool
-                                namespace: metallb-system
-                              spec:
-                                addresses:
-                                  - {{ .controlPlaneEndpointHost }}/32
-                                serviceAllocation:
-                                  priority: 100
-                                  namespaces:
-                                    - default
-                                  serviceSelectors:
-                                    - matchExpressions:
-                                      - {key: "serviceType", operator: In, values: [kubernetes-vip]}
-                              ---
-                              apiVersion: metallb.io/v1beta1
-                              kind: L2Advertisement
-                              metadata:
-                                name: ip-pool-l2-adv
-                                namespace: metallb-system
-                              spec:
-                                ipAddressPools:
-                                  - kubernetes-vip-ip-pool
-                        - path: /var/lib/rancher/rke2/server/manifests/endpoint-svc.yaml
-                          overwrite: true
-                          contents:
-                            inline: |
-                              apiVersion: v1
-                              kind: Service
-                              metadata:
-                                name: kubernetes-vip
-                                namespace: default
-                                labels:
-                                  serviceType: kubernetes-vip
-                              spec:
-                                ports:
-                                - name: rke2-api
-                                  port: 9345
-                                  protocol: TCP
-                                  targetPort: 9345
-                                - name: k8s-api
-                                  port: 6443
-                                  protocol: TCP
-                                  targetPort: 6443
-                                type: LoadBalancer
-                    systemd:
-                      units:
-                        - name: rke2-preinstall.service
-                          enabled: true
-                          contents: |
-                            [Unit]
-                            Description=rke2-preinstall
-                            Wants=network-online.target
-                            Before=rke2-install.service
-                            ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
-                            [Service]
-                            Type=oneshot
-                            User=root
-                            ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
-                            ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
-                            ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
-                            ExecStartPost=/bin/sh -c "umount /mnt"
-                            [Install]
-                            WantedBy=multi-user.target
+  - name: setControlPlaneMachineTemplate
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/machineTemplate/infrastructureRef/name"
+        valueFrom:
+          variable: controlPlaneMachineTemplate
+  - name: setControlPlaneEndpoint
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3ClusterTemplate
+        matchResources:
+          infrastructureCluster: true      # Added to select InfraCluster
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/controlPlaneEndpoint/host"
+        valueFrom:
+          variable: controlPlaneEndpointHost
+  - name: setRegistrationAddress
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true      # Added to select ControlPlane
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/registrationAddress"
+        valueFrom:
+          variable: controlPlaneEndpointHost
+  - name: setTlsSan
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true      # Added to select ControlPlane
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/serverConfig/tlsSan"
+        valueFrom:
+          variable: tlsSan
+  - name: updateAdditionalUserData
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+        kind: RKE2ControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: "/spec/template/spec/agentConfig/additionalUserData"
+        valueFrom:
+          template: |
+            config: |
+              variant: fcos
+              version: 1.4.0
+              storage:
+                files:
+                  - path: /var/lib/rancher/rke2/server/manifests/endpoint-copier-operator.yaml
+                    overwrite: true
+                    contents:
+                      inline: |
+                        apiVersion: helm.cattle.io/v1
+                        kind: HelmChart
+                        metadata:
+                          name: endpoint-copier-operator
+                          namespace: kube-system
+                        spec:
+                          chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
+                          targetNamespace: endpoint-copier-operator
+                          version: 305.0.1+up0.3.0
+                          createNamespace: true
+                  - path: /var/lib/rancher/rke2/server/manifests/metallb.yaml
+                    overwrite: true
+                    contents:
+                      inline: |
+                        apiVersion: helm.cattle.io/v1
+                        kind: HelmChart
+                        metadata:
+                          name: metallb
+                          namespace: kube-system
+                        spec:
+                          chart: oci://registry.suse.com/edge/charts/metallb
+                          targetNamespace: metallb-system
+                          version: 305.0.1+up0.15.2
+                          createNamespace: true
+                  - path: /var/lib/rancher/rke2/server/manifests/metallb-cr.yaml
+                    overwrite: true
+                    contents:
+                      inline: |
+                        apiVersion: metallb.io/v1beta1
+                        kind: IPAddressPool
+                        metadata:
+                          name: kubernetes-vip-ip-pool
+                          namespace: metallb-system
+                        spec:
+                          addresses:
+                            - {{ .controlPlaneEndpointHost }}/32
+                          serviceAllocation:
+                            priority: 100
+                            namespaces:
+                              - default
+                            serviceSelectors:
+                              - matchExpressions:
+                                - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                        ---
+                        apiVersion: metallb.io/v1beta1
+                        kind: L2Advertisement
+                        metadata:
+                          name: ip-pool-l2-adv
+                          namespace: metallb-system
+                        spec:
+                          ipAddressPools:
+                            - kubernetes-vip-ip-pool
+                  - path: /var/lib/rancher/rke2/server/manifests/endpoint-svc.yaml
+                    overwrite: true
+                    contents:
+                      inline: |
+                        apiVersion: v1
+                        kind: Service
+                        metadata:
+                          name: kubernetes-vip
+                          namespace: default
+                          labels:
+                            serviceType: kubernetes-vip
+                        spec:
+                          ports:
+                          - name: rke2-api
+                            port: 9345
+                            protocol: TCP
+                            targetPort: 9345
+                          - name: k8s-api
+                            port: 6443
+                            protocol: TCP
+                            targetPort: 6443
+                          type: LoadBalancer
+              systemd:
+                units:
+                  - name: rke2-preinstall.service
+                    enabled: true
+                    contents: |
+                      [Unit]
+                      Description=rke2-preinstall
+                      Wants=network-online.target
+                      Before=rke2-install.service
+                      ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                      [Service]
+                      Type=oneshot
+                      User=root
+                      ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                      ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                      ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                      ExecStartPost=/bin/sh -c "umount /mnt"
+                      [Install]
+                      WantedBy=multi-user.target
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlaneTemplate
 metadata:
   name: example-controlplane
@@ -205,11 +204,12 @@ metadata:
 spec:
   template:
     spec:
-      infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: Metal3MachineTemplate
-        name: example-controlplane    # This will be replaced by the patch when apply the cluster instance
-        namespace: emea-spa
+      machineTemplate:
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: Metal3MachineTemplate
+          name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
+          namespace: emea-spa
       replicas: 1
       version: ${RKE2_VERSION}
       rolloutStrategy:
@@ -222,7 +222,7 @@ spec:
         cni: cilium
         cniMultusEnable: true
         tlsSan:
-          - "TO_BE_REPLACED"  # This will be replaced by the patch when apply the cluster instance
+        - "TO_BE_REPLACED"    # This will be replaced by the patch when apply the cluster instance
       agentConfig:
         format: ignition
         additionalUserData:
@@ -230,10 +230,10 @@ spec:
             TO_BE_REPLACED
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3ClusterTemplate
 metadata:
   name: example-cluster-template

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance1.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance1.yaml
@@ -1,9 +1,4 @@
-# This is the cluster instance for the cluster class example-clusterclass template definition.
-# Applying this will create a cluster with the name emea-spa-cluster-1 in the emea-spa namespace.
-# Only contains the information needed to create the cluster, because the rest of the information is in the cluster class definition.
-# To select the clusterclass to be used, the class name is specified in the topology section.
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: emea-spa-cluster-1
@@ -12,27 +7,29 @@ metadata:
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   topology:
-    class: example-clusterclass      # ClusterClass name to be used. It should be the same as the one used in the ClusterClass definition.
+    classRef:
+      name: example-clusterclass
+      namespace: emea-spa
     version: ${RKE2_VERSION}
     controlPlane:
       replicas: 1
     variables:                       # Values to be replaced in the clusterclass template variables to create this specific cluster.
-      - name: controlPlaneMachineTemplate
-        value: emea-spa-cluster-1-machinetemplate
-      - name: controlPlaneEndpointHost
-        value: ${CONTROL_PLANE_ENDPOINT_HOST}
-      - name: tlsSan
-        value:
-          - ${CONTROL_PLANE_ENDPOINT_HOST}
-          - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
+    - name: controlPlaneMachineTemplate
+      value: emea-spa-cluster-1-machinetemplate
+    - name: controlPlaneEndpointHost
+      value: ${CONTROL_PLANE_ENDPOINT_HOST}
+    - name: tlsSan
+      value:
+      - ${CONTROL_PLANE_ENDPOINT_HOST}
+      - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-1-machinetemplate
   namespace: emea-spa
 spec:
-  nodeReuse: True
+  nodeReuse: true
   template:
     spec:
       automatedCleaningMode: metadata
@@ -49,7 +46,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-1
@@ -58,7 +55,7 @@ spec:
   clusterName: emea-spa-cluster-1
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance2.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance2.yaml
@@ -1,9 +1,4 @@
-# This is the cluster instance for the cluster class example-clusterclass template definition.
-# Applying this will create a cluster with the name emea-spa-cluster-2 in the emea-spa namespace.
-# Only contains the information needed to create the cluster, because the rest of the information is in the cluster class definition.
-# To select the clusterclass to be used, the class name is specified in the topology section.
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: emea-spa-cluster-2
@@ -12,27 +7,29 @@ metadata:
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   topology:
-    class: example-clusterclass      # ClusterClass name to be used. It should be the same as the one used in the ClusterClass definition.
+    classRef:
+      name: example-clusterclass
+      namespace: emea-spa
     version: ${RKE2_VERSION}
     controlPlane:
       replicas: 1
     variables:                       # Values to be replaced in the clusterclass template variables to create this specific cluster.
-      - name: controlPlaneMachineTemplate
-        value: emea-spa-cluster-2-machinetemplate
-      - name: controlPlaneEndpointHost
-        value: ${CONTROL_PLANE_ENDPOINT_HOST}
-      - name: tlsSan
-        value:
-          - ${CONTROL_PLANE_ENDPOINT_HOST}
-          - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
+    - name: controlPlaneMachineTemplate
+      value: emea-spa-cluster-2-machinetemplate
+    - name: controlPlaneEndpointHost
+      value: ${CONTROL_PLANE_ENDPOINT_HOST}
+    - name: tlsSan
+      value:
+      - ${CONTROL_PLANE_ENDPOINT_HOST}
+      - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-2-machinetemplate
   namespace: emea-spa
 spec:
-  nodeReuse: True
+  nodeReuse: true
   template:
     spec:
       automatedCleaningMode: metadata
@@ -49,7 +46,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-2
@@ -58,7 +55,7 @@ spec:
   clusterName: emea-spa-cluster-2
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -34,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -92,11 +92,11 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
-        - "--config=/etc/kubernetes/kubeletconfig.yml"
+      - provider-id=metal3://BAREMETALHOST_UUID
+      - "--config=/etc/kubernetes/kubeletconfig.yml"
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -115,7 +115,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -124,9 +124,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: calico
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -181,10 +182,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -199,16 +200,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: canal
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -181,10 +182,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -199,16 +200,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -189,10 +190,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -207,16 +208,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -225,9 +226,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: calico
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -137,10 +138,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -160,7 +161,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -169,9 +170,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: calico
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -152,10 +153,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -175,7 +176,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -184,9 +185,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: canal
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -137,10 +138,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -160,7 +161,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -169,9 +170,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: canal
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -152,10 +153,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -175,7 +176,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -184,9 +185,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: cilium
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -156,10 +157,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -179,7 +180,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -188,9 +189,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: cilium
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -171,10 +172,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -194,7 +195,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -203,9 +204,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: calico
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: canal
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,7 +35,7 @@ spec:
 
 ## Control Plane
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -43,10 +43,11 @@ metadata:
   annotations:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -58,8 +59,8 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_VIP_ADDRESS}
-      - https://${EDGE_VIP_ADDRESS}.sslip.io
+    - ${EDGE_VIP_ADDRESS}
+    - https://${EDGE_VIP_ADDRESS}.sslip.io
   agentConfig:
     format: ignition
     additionalUserData:
@@ -168,10 +169,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -190,7 +191,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -199,15 +200,15 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ## Workers
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -230,18 +231,19 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
-      nodeDrainTimeout: 0s
+      deletion:
+        nodeDrainTimeoutSeconds: 0
       version: ${RKE2_VERSION}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: multinode-cluster-workers
@@ -253,7 +255,7 @@ spec:
         format: ignition
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "Node-multinode-cluster-worker"
         additionalUserData:
           config: |
@@ -279,7 +281,7 @@ spec:
                     [Install]
                     WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -298,7 +300,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template
@@ -307,9 +309,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -33,7 +33,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -41,10 +41,11 @@ metadata:
   annotations:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,8 +57,8 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_VIP_ADDRESS}
-      - https://${EDGE_VIP_ADDRESS}.sslip.io
+    - ${EDGE_VIP_ADDRESS}
+    - https://${EDGE_VIP_ADDRESS}.sslip.io
   agentConfig:
     format: ignition
     additionalUserData:
@@ -166,10 +167,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -188,7 +189,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -197,9 +198,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -34,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +55,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -215,10 +215,10 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -237,7 +237,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -246,9 +246,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -34,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +55,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -297,10 +297,10 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -319,7 +319,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slemicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -328,9 +328,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -140,10 +141,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -163,7 +164,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -172,9 +173,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -153,10 +154,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -176,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -185,9 +186,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -140,10 +141,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -163,7 +164,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -172,9 +173,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -153,10 +154,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -176,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -185,9 +186,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -145,10 +146,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -168,7 +169,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -177,9 +178,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -161,10 +162,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -184,7 +185,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -193,9 +194,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -102,10 +103,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -125,7 +126,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -134,9 +135,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -111,10 +112,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -134,7 +135,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -143,9 +144,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -92,10 +93,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -115,7 +116,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -124,9 +125,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: calico
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -181,10 +182,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -199,16 +200,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: canal
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -181,10 +182,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -199,16 +200,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -181,10 +182,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -199,16 +200,16 @@ spec:
         matchLabels:
           cluster-role: control-plane
         matchExpressions:
-          - key: node
-            operator: In
-            values: ["node-1", "node-2"]
+        - key: node
+          operator: In
+          values: ["node-1", "node-2"]
       image:
         checksum: http://imagecache.local:8080/eibimage-slmicro-rt.raw.sha256
         checksumType: sha256
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: calico
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -137,10 +138,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -160,7 +161,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -169,9 +170,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: calico
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -152,10 +153,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -175,7 +176,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -184,9 +185,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: canal
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -137,10 +138,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -160,7 +161,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -169,9 +170,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: canal
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -152,10 +153,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -175,7 +176,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -184,9 +185,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: cilium
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -156,10 +157,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -179,7 +180,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -188,9 +189,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -56,7 +57,7 @@ spec:
     cni: cilium
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -171,10 +172,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -194,7 +195,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -203,9 +204,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: calico
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: canal
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,22 +9,22 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
-        - fd00:bad:face::/48
+      - 192.168.0.0/18
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - 10.96.0.0/12
-        - fd00:bad:deaf:beef::/112
+      - 10.96.0.0/12
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -35,16 +35,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +56,7 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_CONTROL_PLANE_IP_V6}
+    - ${EDGE_CONTROL_PLANE_IP_V6}
   agentConfig:
     format: ignition
     cisProfile: cis
@@ -97,10 +98,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -120,7 +121,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -129,9 +130,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -35,7 +35,7 @@ spec:
 
 ## Control Plane
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -43,10 +43,11 @@ metadata:
   annotations:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -58,8 +59,8 @@ spec:
   serverConfig:
     cni: cilium
     tlsSan:
-      - ${EDGE_VIP_ADDRESS}
-      - https://${EDGE_VIP_ADDRESS}.sslip.io
+    - ${EDGE_VIP_ADDRESS}
+    - https://${EDGE_VIP_ADDRESS}.sslip.io
   agentConfig:
     format: ignition
     additionalUserData:
@@ -168,10 +169,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -190,7 +191,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -199,15 +200,15 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine
 ## Workers
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   labels:
@@ -230,18 +231,19 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
-      nodeDrainTimeout: 0s
+      deletion:
+        nodeDrainTimeoutSeconds: 0
       version: ${RKE2_VERSION}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: RKE2ConfigTemplate
 metadata:
   name: multinode-cluster-workers
@@ -253,7 +255,7 @@ spec:
         format: ignition
         kubelet:
           extraArgs:
-            - provider-id=metal3://BAREMETALHOST_UUID
+          - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "Node-multinode-cluster-worker"
         additionalUserData:
           config: |
@@ -279,7 +281,7 @@ spec:
                     [Install]
                     WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -298,7 +300,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template
@@ -307,9 +309,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: multinode-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -33,7 +33,7 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: multinode-cluster
@@ -41,10 +41,11 @@ metadata:
   annotations:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: multinode-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -57,8 +58,8 @@ spec:
     cni: cilium
     cniMultusEnable: true
     tlsSan:
-      - ${EDGE_VIP_ADDRESS}
-      - https://${EDGE_VIP_ADDRESS}.sslip.io
+    - ${EDGE_VIP_ADDRESS}
+    - https://${EDGE_VIP_ADDRESS}.sslip.io
   agentConfig:
     format: ignition
     additionalUserData:
@@ -186,10 +187,10 @@ spec:
                     type: LoadBalancer
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -208,7 +209,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -217,9 +218,9 @@ spec:
   clusterName: multinode-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -34,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +55,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -215,10 +215,10 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -237,7 +237,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -246,9 +246,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -10,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/18
+      - 192.168.0.0/18
     services:
       cidrBlocks:
-        - 10.96.0.0/12
+      - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -34,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -55,7 +55,7 @@ spec:
     cni: calico
     cniMultusEnable: true
   preRKE2Commands:
-    - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
+  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:
@@ -297,10 +297,10 @@ spec:
                 WantedBy=multi-user.target
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -319,7 +319,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slemicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -328,9 +328,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -140,10 +141,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -163,7 +164,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -172,9 +173,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -153,10 +154,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -176,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -185,9 +186,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -140,10 +141,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -163,7 +164,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -172,9 +173,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -153,10 +154,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -176,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -185,9 +186,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -145,10 +146,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -168,7 +169,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -177,9 +178,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -161,10 +162,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -184,7 +185,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -193,9 +194,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -102,10 +103,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -125,7 +126,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -134,9 +135,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -111,10 +112,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -134,7 +135,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -143,9 +144,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: single-node-cluster
@@ -9,20 +9,20 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - fd00:bad:face::/48
+      - fd00:bad:face::/48
     services:
       cidrBlocks:
-        - fd00:bad:deaf:beef::/112
+      - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -33,16 +33,17 @@ spec:
     port: 6443
   noCloudProvider: true
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: single-node-cluster
   namespace: default
 spec:
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: Metal3MachineTemplate
-    name: single-node-cluster-controlplane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      kind: Metal3MachineTemplate
+      name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:
@@ -92,10 +93,10 @@ spec:
                 name: root
     kubelet:
       extraArgs:
-        - provider-id=metal3://BAREMETALHOST_UUID
+      - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -115,7 +116,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template
@@ -124,9 +125,9 @@ spec:
   clusterName: single-node-cluster
   metaData:
     objectNames:
-      - key: name
-        object: machine
-      - key: local-hostname
-        object: machine
-      - key: local_hostname
-        object: machine
+    - key: name
+      object: machine
+    - key: local-hostname
+      object: machine
+    - key: local_hostname
+      object: machine


### PR DESCRIPTION
Migrate the resources as described in https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/tutorials/capi-v1beta2.html

Note this used a script which was generated with assistance from Claude, I've included the script and the generated md file.