### PR TITLE
v1beta2: nest infrastructureRef under machineTemplate.spec

### DIFF
--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: test-cluster-minimal-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: test-cluster-minimal-controlplane
   replicas: 1
   agentConfig:
     format: ignition

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: test-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: test-cluster-controlplane
   replicas: 1
   serverConfig:
     cni: calico

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -62,10 +62,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -42,7 +42,7 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: replace
-        path: "/spec/template/spec/machineTemplate/infrastructureRef/name"
+        path: "/spec/template/spec/machineTemplate/spec/infrastructureRef/name"
         valueFrom:
           variable: controlPlaneMachineTemplate
   - name: setControlPlaneEndpoint
@@ -205,11 +205,12 @@ spec:
   template:
     spec:
       machineTemplate:
-        infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-          kind: Metal3MachineTemplate
-          name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
-          namespace: emea-spa
+        spec:
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            kind: Metal3MachineTemplate
+            name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
+            namespace: emea-spa
       replicas: 1
       version: ${RKE2_VERSION}
       rolloutStrategy:

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -44,10 +44,11 @@ metadata:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -42,10 +42,11 @@ metadata:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 2
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -42,10 +42,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -44,10 +44,11 @@ metadata:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -42,10 +42,11 @@ metadata:
     rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: multinode-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: multinode-cluster-controlplane
   replicas: 3
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -40,10 +40,11 @@ metadata:
   namespace: default
 spec:
   machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
-      kind: Metal3MachineTemplate
-      name: single-node-cluster-controlplane
+    spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        kind: Metal3MachineTemplate
+        name: single-node-cluster-controlplane
   replicas: 1
   version: ${RKE2_VERSION}
   rolloutStrategy:


### PR DESCRIPTION
In the v1beta2 RKE2ControlPlane and RKE2ControlPlaneTemplate APIs, the machineTemplate field is of type RKE2ControlPlaneMachineTemplate which requires a nested spec field that holds infrastructureRef (and the deletion timeouts). The previous v1beta2 migration in #89 placed infrastructureRef directly under machineTemplate, which is not a valid field at that level.

See:
- https://github.com/rancher/cluster-api-provider-rke2/blob/main/controlplane/api/v1beta2/rke2controlplane_types.go
- https://documentation.suse.com/cloudnative/cluster-api/v0.26/en/tutorials/capi-v1beta2.html