### PR TITLE
Metal3Cluster migrate noCloudProvider and v1beta2 fixes

### DIFF
--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: test-cluster-minimal
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: test-cluster-minimal
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: test-cluster-minimal
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: test-cluster-minimal-controlplane
   replicas: 1
@@ -77,7 +77,7 @@ spec:
     version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: test-cluster-minimal-controlplane
@@ -96,7 +96,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco-arm.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: test-cluster-minimal-controlplane-template

--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: test-cluster-minimal
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: test-cluster-minimal
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: test-cluster-minimal-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-minimal.yaml
@@ -33,7 +33,7 @@ spec:
     port: 6443
   cloudProviderEnabled: false
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: test-cluster-minimal

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: test-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: test-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: test-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -33,7 +33,7 @@ spec:
     port: 6443
   cloudProviderEnabled: false
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane
 metadata:
   name: test-cluster

--- a/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/edge-clusters/aarch64/capi-telco-aarch64.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: test-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: test-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: test-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: test-cluster-controlplane
   replicas: 1
@@ -215,7 +215,7 @@ spec:
     version: ${RKE2_VERSION}
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: test-cluster-controlplane
@@ -234,7 +234,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco-arm.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: test-cluster-controlplane-template

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -53,7 +53,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -40,11 +40,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -64,7 +64,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -327,7 +327,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -346,7 +346,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/edge-clusters/airgap/edge-telco-airgap/telco-capi-airgap.yaml
@@ -36,11 +36,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -64,7 +64,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -245,4 +245,4 @@ spec:
       controlPlaneEndpoint:
         host: "TO_BE_REPLACED"  # This will be replaced by the patch when apply the cluster instance
         port: 6443
-      noCloudProvider: true
+      cloudProviderEnabled: false

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -25,7 +25,7 @@ spec:
   infrastructure:
     templateRef:
       kind: Metal3ClusterTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: example-cluster-template
   controlPlane:
     templateRef:
@@ -48,7 +48,7 @@ spec:
   - name: setControlPlaneEndpoint
     definitions:
     - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3ClusterTemplate
         matchResources:
           infrastructureCluster: true      # Added to select InfraCluster
@@ -207,7 +207,7 @@ spec:
       machineTemplate:
         spec:
           infrastructureRef:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: Metal3MachineTemplate
             name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
             namespace: emea-spa
@@ -234,7 +234,7 @@ spec:
           - provider-id=metal3://BAREMETALHOST_UUID
         nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3ClusterTemplate
 metadata:
   name: example-cluster-template

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -210,7 +210,6 @@ spec:
             apiGroup: infrastructure.cluster.x-k8s.io
             kind: Metal3MachineTemplate
             name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
-            namespace: emea-spa
       replicas: 1
       version: ${RKE2_VERSION}
       rolloutStrategy:

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/classes/clusterclass-definition.yaml
@@ -207,7 +207,7 @@ spec:
       machineTemplate:
         spec:
           infrastructureRef:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            apiGroup: infrastructure.cluster.x-k8s.io
             kind: Metal3MachineTemplate
             name: example-controlplane  # This will be replaced by the patch when apply the cluster instance
             namespace: emea-spa

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance1.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance1.yaml
@@ -23,7 +23,7 @@ spec:
       - ${CONTROL_PLANE_ENDPOINT_HOST}
       - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-1-machinetemplate
@@ -46,7 +46,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-1

--- a/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance2.yaml
+++ b/telco-examples/edge-clusters/clusterclass/edge-telco-clusterclass/cluster-instance2.yaml
@@ -23,7 +23,7 @@ spec:
       - ${CONTROL_PLANE_ENDPOINT_HOST}
       - https://${CONTROL_PLANE_ENDPOINT_HOST}.sslip.io
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: emea-spa-cluster-2-machinetemplate
@@ -46,7 +46,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-downstream-cluster.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: emea-spa-cluster-2

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -97,7 +97,7 @@ spec:
       - "--config=/etc/kubernetes/kubeletconfig.yml"
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -116,7 +116,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
+++ b/telco-examples/edge-clusters/cpu-manager/edge-telco-single-node/telco-capi-cpu-manager.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -186,7 +186,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -186,7 +186,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -194,7 +194,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -218,7 +218,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -142,7 +142,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -162,7 +162,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -157,7 +157,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -177,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -142,7 +142,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -162,7 +162,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -157,7 +157,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -177,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -161,7 +161,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -181,7 +181,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -176,7 +176,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -196,7 +196,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -46,7 +46,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -232,12 +232,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
       deletion:

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -46,7 +46,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -173,7 +173,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -192,7 +192,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -237,7 +237,7 @@ spec:
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
       deletion:
@@ -282,7 +282,7 @@ spec:
                     [Install]
                     WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -301,7 +301,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_VIP_ADDRESS}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 
 ## Control Plane
 ---

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_VIP_ADDRESS}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -171,7 +171,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -190,7 +190,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -219,7 +219,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -238,7 +238,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -301,7 +301,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -320,7 +320,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slemicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/edge-telco-single-node/telco-capi-single-node.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -145,7 +145,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -165,7 +165,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -158,7 +158,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -178,7 +178,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -145,7 +145,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -165,7 +165,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -158,7 +158,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -178,7 +178,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -150,7 +150,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -170,7 +170,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -166,7 +166,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -186,7 +186,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -107,7 +107,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -127,7 +127,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -116,7 +116,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -136,7 +136,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp-less/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -97,7 +97,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -117,7 +117,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -186,7 +186,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -186,7 +186,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2
@@ -186,7 +186,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/multi-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 2

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -142,7 +142,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -162,7 +162,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-calico_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -157,7 +157,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -177,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -142,7 +142,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -162,7 +162,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-canal_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -157,7 +157,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -177,7 +177,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -161,7 +161,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -181,7 +181,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_hostlocal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/multus-cni/Telco-capi-v4v6-cilium_whereabouts.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -176,7 +176,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -196,7 +196,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-calico.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-canal.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -16,11 +16,11 @@ spec:
       - 10.96.0.0/12
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -33,7 +33,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP_V4}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/dual-stack/single-node/single-cni/Telco-capi-v4v6-cilium.yaml
@@ -20,11 +20,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -102,7 +102,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -122,7 +122,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -46,7 +46,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -232,12 +232,12 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: RKE2ConfigTemplate
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
       deletion:

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -46,7 +46,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -173,7 +173,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -192,7 +192,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template
@@ -237,7 +237,7 @@ spec:
           name: multinode-cluster-workers
       clusterName: multinode-cluster
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-workers
       deletion:
@@ -282,7 +282,7 @@ spec:
                     [Install]
                     WantedBy=multi-user.target
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-workers
@@ -301,7 +301,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-workers-template

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-cp-with-workers/telco-capi-metallb-multi-node-with-workers.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_VIP_ADDRESS}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 
 ## Control Plane
 ---

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_VIP_ADDRESS}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: multinode-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: multinode-cluster
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3
@@ -191,7 +191,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "Node-multinode-cluster"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: multinode-cluster-controlplane
@@ -210,7 +210,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: multinode-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-metallb-multi-node/multi-node-only-cp/telco-capi-metallb-multi-node.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: multinode-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: multinode-cluster
 ---
@@ -44,7 +44,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: multinode-cluster-controlplane
   replicas: 3

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -219,7 +219,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -238,7 +238,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -301,7 +301,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -320,7 +320,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slemicro-rt-telco.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/edge-clusters/dhcp/edge-telco-single-node/telco-capi-single-node.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - 10.96.0.0/12
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -145,7 +145,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -165,7 +165,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-calico_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -158,7 +158,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -178,7 +178,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -145,7 +145,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -165,7 +165,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-canal_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -158,7 +158,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -178,7 +178,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -150,7 +150,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -170,7 +170,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_hostlocal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/multus-cni/Telco-capi-v6-cilium_whereabouts.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -166,7 +166,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -186,7 +186,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -107,7 +107,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -127,7 +127,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-calico.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: "${EDGE_CONTROL_PLANE_IP}"
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-canal.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -116,7 +116,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -136,7 +136,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -31,7 +31,7 @@ spec:
   controlPlaneEndpoint:
     host: ${EDGE_CONTROL_PLANE_IP}
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: RKE2ControlPlane

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -14,11 +14,11 @@ spec:
       cidrBlocks:
       - fd00:bad:deaf:beef::/112
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    apiGroup: controlplane.cluster.x-k8s.io
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: Metal3Cluster
     name: single-node-cluster
 ---
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1

--- a/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
+++ b/telco-examples/edge-clusters/dhcp/ipv6/single-node/single-cni/Telco-capi-v6-cilium.yaml
@@ -18,11 +18,11 @@ spec:
     kind: RKE2ControlPlane
     name: single-node-cluster
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: Metal3Cluster
     name: single-node-cluster
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3Cluster
 metadata:
   name: single-node-cluster
@@ -42,7 +42,7 @@ spec:
   machineTemplate:
     spec:
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate
         name: single-node-cluster-controlplane
   replicas: 1
@@ -97,7 +97,7 @@ spec:
       - provider-id=metal3://BAREMETALHOST_UUID
     nodeName: "localhost.localdomain"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate
 metadata:
   name: single-node-cluster-controlplane
@@ -117,7 +117,7 @@ spec:
         format: raw
         url: http://imagecache.local:8080/eibimage-slmicro-rt.raw
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3DataTemplate
 metadata:
   name: single-node-cluster-controlplane-template


### PR DESCRIPTION
As described in the docs[1] noCloudProvider is deprecated and will be removed in the v1beta2 for 1.13 onwards[2]

Also includes some v1beta2 fixes that were missed in #89

[1] https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/api.md#metal3cluster
[2] https://github.com/metal3-io/cluster-api-provider-metal3/pull/3170