### PR TITLE
Update Metal3 configuration for airgap deployments

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  additionalTrustedCAs: false
+  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/metal3.yaml
@@ -1,8 +1,10 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  additionalTrustedCAs: false
+  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
+  ipa:
+    useHauler: true
   global:
     predictableNicNames: "true"
   persistence:

--- a/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/mgmt-cluster-airgap.yaml
@@ -162,3 +162,4 @@ embeddedArtifactRegistry:
     - name: registry.rancher.com/rancher/mirrored-cluster-api-controller:v1.12.2
     - name: registry.rancher.com/rancher/scc-operator:v0.4.0
     - name: registry.rancher.com/rancher/kubectl:v1.35.2
+    - name: registry.suse.com/edge/3.5/ironic-python-agent:3.0.8

--- a/telco-examples/mgmt-cluster/dual-stack/single-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/dual-stack/single-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP_V4}
   enable_vmedia_tls: false
-  additionalTrustedCAs: false
+  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: true

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${METAL3_VIP}
   enable_vmedia_tls: false
-  additionalTrustedCAs: false
+  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  additionalTrustedCAs: false
+  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"


### PR DESCRIPTION
Changes based on documentation updates from suse-edge/suse-edge.github.io PRs #1131 and #1127:

1. Replace removed additionalTrustedCAs with trustedCA ConfigMap approach
   - Changed from `global.additionalTrustedCAs: false` to commented `# trustedCA: tls-ca-bundle`
   - Applied to all metal3.yaml files across mgmt-cluster examples

2. Add IPA image and useHauler configuration for airgap deployment
   - Added `metal3-ironic.ipa.useHauler: true` to mgmt-cluster/airgap metal3.yaml
   - Added ironic-python-agent:3.0.8 image to embeddedArtifactRegistry in airgap definition file
   - Required for Metal3 to retrieve IPA image from embedded registry in airgap environments