### PR TITLE
Fix a typo in trustedCAs value name

### DIFF
--- a/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/aarch64/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   ipa:
     useHauler: true

--- a/telco-examples/mgmt-cluster/dual-stack/single-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/dual-stack/single-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP_V4}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: true

--- a/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/multi-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${METAL3_VIP}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"

--- a/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/metal3.yaml
+++ b/telco-examples/mgmt-cluster/single-node/eib/kubernetes/helm/values/metal3.yaml
@@ -1,7 +1,7 @@
 global:
   ironicIP: ${MGMT_CLUSTER_IP}
   enable_vmedia_tls: false
-  # trustedCA: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
+  # trustedCAs: tls-ca-bundle  # Optional: Uncomment and set to ConfigMap name containing full CA bundle
 metal3-ironic:
   global:
     predictableNicNames: "true"


### PR DESCRIPTION
Will need backport to 3.6 branch (if created before this get merged)