### PR TITLE
Backport edge1984 2113 to release 3.6

### DIFF
--- a/telco-examples/downstream-clusters/aarch64/capi-telco-aarch64.yaml
+++ b/telco-examples/downstream-clusters/aarch64/capi-telco-aarch64.yaml
@@ -49,8 +49,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:

--- a/telco-examples/downstream-clusters/aarch64/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
+++ b/telco-examples/downstream-clusters/aarch64/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
@@ -1,0 +1,2 @@
+# Enable SR-IOV and disable idle D3 state for vfio-pci driver
+options vfio_pci enable_sriov=1 disable_idle_d3=1

--- a/telco-examples/downstream-clusters/aarch64/eib/os-files/etc/modules-load.d/vfio-pci.conf
+++ b/telco-examples/downstream-clusters/aarch64/eib/os-files/etc/modules-load.d/vfio-pci.conf
@@ -1,0 +1,3 @@
+# Request "systemd-modules-load.service" to load vfio-pci module at boot time
+# NOTE: The (SRIOV & DPDK related) required load-module options settings are defined in related "/etc/modprobe.d/vfio-pci-options.conf" file
+vfio_pci

--- a/telco-examples/downstream-clusters/airgap/downstream-telco-airgap/telco-capi-airgap.yaml
+++ b/telco-examples/downstream-clusters/airgap/downstream-telco-airgap/telco-capi-airgap.yaml
@@ -118,8 +118,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     airGapped: true       # Airgap true to enable airgap mode
     format: ignition

--- a/telco-examples/downstream-clusters/airgap/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
+++ b/telco-examples/downstream-clusters/airgap/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
@@ -1,0 +1,2 @@
+# Enable SR-IOV and disable idle D3 state for vfio-pci driver
+options vfio_pci enable_sriov=1 disable_idle_d3=1

--- a/telco-examples/downstream-clusters/airgap/eib/os-files/etc/modules-load.d/vfio-pci.conf
+++ b/telco-examples/downstream-clusters/airgap/eib/os-files/etc/modules-load.d/vfio-pci.conf
@@ -1,0 +1,3 @@
+# Request "systemd-modules-load.service" to load vfio-pci module at boot time
+# NOTE: The (SRIOV & DPDK related) required load-module options settings are defined in related "/etc/modprobe.d/vfio-pci-options.conf" file
+vfio_pci

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -55,8 +55,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node.yaml
@@ -280,20 +280,20 @@ spec:
                 ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
                 [Install]
                 WantedBy=multi-user.target
-            - name: dpdk-vf-creation.service
+            - name: dpdk-bbdev-vf-creation.service
               enabled: true
               contents: |
                 [Unit]
-                Description=DPDK VF creation service
+                Description=DPDK-BBDEV PF config and VF creation service
                 Wants=network-online.target  rke2-server.target
                 After=network.target network-online.target rke2-server.target
                 [Service]
                 User=root
                 Type=forking
                 TimeoutStartSec=900
-                ExecStart=/bin/sh -c "dpdk-devbind.py -b vfio-pci ${DPDK_PCI_ADDRESS}"
-                ExecStartPost=/bin/sh -c "echo 1 > /sys/bus/pci/devices/${DPDK_PCI_ADDRESS}/sriov_numvfs"
-                ExecStartPost=/bin/sh -c "pf_bb_config ACC200 -v 00112233-4455-6677-8899-aabbccddeeff -c /opt/pf-bb-config/acc200_config_vf_5g.cfg; sleep 2"
+                ExecStart=/bin/sh -c "dpdk-devbind.py -b vfio-pci ${DPDK_ACC_PCI_ADDRESS}"
+                ExecStartPost=/bin/sh -c "echo 1 > /sys/bus/pci/devices/${DPDK_ACC_PCI_ADDRESS}/sriov_numvfs"
+                ExecStartPost=/bin/sh -c "pf_bb_config VRB1 -v 00112233-4455-6677-8899-aabbccddeeff -c /usr/share/pf-bb-config/examples/vrb1/vrb1_config_vf_5g.cfg -f /usr/share/pf-bb-config/examples/vrb1/srs_fft_windows_coefficient.bin -p ${DPDK_ACC_PCI_ADDRESS}; sleep 2"
                 RemainAfterExit=yes
                 KillMode=process
                 [Install]

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/telco-capi-single-node.yaml
@@ -55,8 +55,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:

--- a/telco-examples/downstream-clusters/dhcp-less/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
+++ b/telco-examples/downstream-clusters/dhcp-less/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
@@ -1,0 +1,2 @@
+# Enable SR-IOV and disable idle D3 state for vfio-pci driver
+options vfio_pci enable_sriov=1 disable_idle_d3=1

--- a/telco-examples/downstream-clusters/dhcp-less/eib/os-files/etc/modules-load.d/vfio-pci.conf
+++ b/telco-examples/downstream-clusters/dhcp-less/eib/os-files/etc/modules-load.d/vfio-pci.conf
@@ -1,0 +1,3 @@
+# Request "systemd-modules-load.service" to load vfio-pci module at boot time
+# NOTE: The (SRIOV & DPDK related) required load-module options settings are defined in related "/etc/modprobe.d/vfio-pci-options.conf" file
+vfio_pci

--- a/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node-sriov-auto.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node-sriov-auto.yaml
@@ -55,8 +55,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:

--- a/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node.yaml
@@ -280,20 +280,20 @@ spec:
                 ExecStart=/bin/sh -c "/opt/performance-settings/performance-settings.sh"
                 [Install]
                 WantedBy=multi-user.target
-            - name: dpdk-vf-creation.service
+            - name: dpdk-bbdev-vf-creation.service
               enabled: true
               contents: |
                 [Unit]
-                Description=DPDK VF creation service
+                Description=DPDK-BBDEV PF config and VF creation service
                 Wants=network-online.target  rke2-server.target
                 After=network.target network-online.target rke2-server.target
                 [Service]
                 User=root
                 Type=forking
                 TimeoutStartSec=900
-                ExecStart=/bin/sh -c "dpdk-devbind.py -b vfio-pci ${DPDK_PCI_ADDRESS}"
-                ExecStartPost=/bin/sh -c "echo 1 > /sys/bus/pci/devices/${DPDK_PCI_ADDRESS}/sriov_numvfs"
-                ExecStartPost=/bin/sh -c "pf_bb_config ACC200 -v 00112233-4455-6677-8899-aabbccddeeff -c /opt/pf-bb-config/acc200_config_vf_5g.cfg; sleep 2"
+                ExecStart=/bin/sh -c "dpdk-devbind.py -b vfio-pci ${DPDK_ACC_PCI_ADDRESS}"
+                ExecStartPost=/bin/sh -c "echo 1 > /sys/bus/pci/devices/${DPDK_ACC_PCI_ADDRESS}/sriov_numvfs"
+                ExecStartPost=/bin/sh -c "pf_bb_config VRB1 -v 00112233-4455-6677-8899-aabbccddeeff -c /usr/share/pf-bb-config/examples/vrb1/vrb1_config_vf_5g.cfg -f /usr/share/pf-bb-config/examples/vrb1/srs_fft_windows_coefficient.bin -p ${DPDK_ACC_PCI_ADDRESS}; sleep 2"
                 RemainAfterExit=yes
                 KillMode=process
                 [Install]

--- a/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/telco-capi-single-node.yaml
@@ -55,8 +55,6 @@ spec:
   serverConfig:
     cni: calico
     cniMultusEnable: true
-  preRKE2Commands:
-  - modprobe vfio-pci enable_sriov=1 disable_idle_d3=1
   agentConfig:
     format: ignition
     additionalUserData:

--- a/telco-examples/downstream-clusters/dhcp/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
+++ b/telco-examples/downstream-clusters/dhcp/eib/os-files/etc/modprobe.d/vfio-pci-options.conf
@@ -1,0 +1,2 @@
+# Enable SR-IOV and disable idle D3 state for vfio-pci driver
+options vfio_pci enable_sriov=1 disable_idle_d3=1

--- a/telco-examples/downstream-clusters/dhcp/eib/os-files/etc/modules-load.d/vfio-pci.conf
+++ b/telco-examples/downstream-clusters/dhcp/eib/os-files/etc/modules-load.d/vfio-pci.conf
@@ -1,0 +1,3 @@
+# Request "systemd-modules-load.service" to load vfio-pci module at boot time
+# NOTE: The (SRIOV & DPDK related) required load-module options settings are defined in related "/etc/modprobe.d/vfio-pci-options.conf" file
+vfio_pci


### PR DESCRIPTION
Backports the following two changes already merged into main (one different commit per each):

- pf-bb-config updates (due to the new pf-bb-config rpm included in STC 3.6.0 release)
- Adds to downstream "eib/os-files/etc/{modules-load.f,modprobe.d}/" folders those two vfio-pci related files for this kernel modules to be automatically load on every node boot with the proper settings