### PR TITLE
Add Rancher hostname configuration options for air-gapped environments

### DIFF
--- a/telco-examples/mgmt-cluster/airgap/README.md
+++ b/telco-examples/mgmt-cluster/airgap/README.md
@@ -34,7 +34,35 @@ You need to modify the `${MGMT_CLUSTER_IP}` with the Node IP in the following fi
 
 - `kubernetes/helm/values/metal3.yaml`
 
-- `kubernetes/helm/values/rancher.yaml`
+## Rancher Hostname Configuration in Air-Gapped Environments
+
+This example uses **Option 1 (Recommended)**: Configure your internal DNS server to resolve the Rancher hostname.
+
+In `kubernetes/helm/values/rancher.yaml`, replace `your-domain.internal` with your actual internal domain:
+
+```yaml
+hostname: rancher.your-domain.internal
+```
+
+Make sure your DNS server resolves `rancher.your-domain.internal` to the appropriate IP address.
+
+### Alternative Option 2: Static /etc/hosts Injection
+
+If internal DNS is not available, you can inject static entries via EIB by creating `eib/os-files/etc/hosts`:
+
+```shell
+# Static DNS resolution for Rancher in air-gapped environment
+${INGRESS_VIP} rancher-${INGRESS_VIP}.sslip.io
+```
+
+Then update `kubernetes/helm/values/rancher.yaml`:
+
+```yaml
+hostname: rancher-${INGRESS_VIP}.sslip.io
+```
+
+> **_IMPORTANT:_**  
+> With Option 2, the `/etc/hosts` file will need to be present on any system that needs to access the Rancher UI, not just the management cluster nodes.
 
 You need to modify the `${MGMT_CLUSTER_REGISTRY_IP}` with a reserved static IP for the SUSE Private Registry in the following file:
 

--- a/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
+++ b/telco-examples/mgmt-cluster/airgap/eib/kubernetes/helm/values/rancher.yaml
@@ -1,4 +1,4 @@
-hostname: rancher-${MGMT_CLUSTER_IP}.sslip.io
+hostname: rancher.your-domain.internal
 bootstrapPassword: "foobar"
 replicas: 1
 global:


### PR DESCRIPTION
Fix issue: https://github.com/suse-edge/suse-edge.github.io/issues/1176

This pull request updates the Rancher hostname configuration for air-gapped management clusters, focusing on improved clarity and best practices for DNS setup. The documentation now recommends using an internal DNS server for Rancher hostname resolution, with an alternative method for environments without DNS.

**Rancher Hostname Configuration Improvements:**

* Updated the recommended Rancher hostname in `rancher.yaml` to use `rancher.your-domain.internal` instead of the previous `${MGMT_CLUSTER_IP}.sslip.io` approach, aligning with best practices for internal DNS usage.
* Expanded the `README.md` with clear instructions for two hostname configuration options: (1) using an internal DNS server (recommended), and (2) using static `/etc/hosts` injection for environments without DNS.
* Added a warning in the documentation that, when using static `/etc/hosts`, all systems accessing the Rancher UI must have the appropriate entry, not just the management cluster nodes.