### PR TITLE
Add examples for multi-node Longhorn with encryption and upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Note that ipv6, dual-stack and aarch64 scenarios are currently tech-preview and 
 - Air gap scenarios for management cluster
 - Additional cacerts to use external TLS file server for managment cluster (to server images over HTTPS)
 - Air gap scenarios for downstream clusters
+- Longhorn scenarios for downstream clusters
 - CPU Manager scenarios
 - AARCH64 architecture:
   1. Tech Preview for full aarch64 e2e, mgmt-cluster and downstream clusters using aarch64 architecture

--- a/telco-examples/downstream-clusters/README.md
+++ b/telco-examples/downstream-clusters/README.md
@@ -99,7 +99,7 @@ The first step is to enroll the new Baremetal host in the management cluster. To
 
 - `${BMC_USERNAME}` - The username for the BMC of the new Baremetal host.
 - `${BMC_PASSWORD}` - The password for the BMC of the new Baremetal host.
-- `${BMC_MAC}` - The MAC address of the new Baremetal host to be used.
+- `${NODE_MAC_BOOT}` - The MAC address of the new Baremetal host to be used.
 - `${BMC_ADDRESS}` - The URL for the Baremetal host BMC (e.g `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). If you want to know more about the different options available depending on your hardware provider, please check the following [link](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md).
 
 > **_Note:_** Please makes sure that the bmh file contains the right architecture for the downstream cluster. In this case, it should be `archictecture: x86_64` in order to match with the image generated in the previous step.
@@ -198,7 +198,7 @@ The first step is to enroll the new Baremetal hosts in the management cluster. T
 
 - `${BMC_NODE1_USERNAME}` - The username for the BMC of the first Baremetal host.
 - `${BMC_NODE1_PASSWORD}` - The password for the BMC of the first Baremetal host.
-- `${BMC_NODE1_MAC}` - The MAC address of the first Baremetal host to be used.
+- `${NODE1_MAC_BOOT}` - The MAC address of the first Baremetal host to be used.
 - `${BMC_NODE1_ADDRESS}` - The URL for the first Baremetal host BMC (e.g `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). If you want to know more about the different options available depending on your hardware provider, please check the following [link](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md).
 
 > **_Note:_** Please makes sure that the bmh file contains the right architecture for the downstream cluster. In this case, it should be `archictecture: x86_64` in order to match with the image generated in the previous step.

--- a/telco-examples/downstream-clusters/aarch64/README.md
+++ b/telco-examples/downstream-clusters/aarch64/README.md
@@ -71,7 +71,7 @@ The first step is to enroll the new Baremetal host in the management cluster. To
 
 - `${BMC_USERNAME}` - The username for the BMC of the new Baremetal host.
 - `${BMC_PASSWORD}` - The password for the BMC of the new Baremetal host.
-- `${BMC_MAC}` - The MAC address of the new Baremetal host to be used.
+- `${NODE_MAC_BOOT}` - The MAC address of the new Baremetal host to be used.
 - `${BMC_ADDRESS}` - The URL for the Baremetal host BMC (e.g `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). If you want to know more about the different options available depending on your hardware provider, please check the following [link](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md).
 
 > **_Note:_** Please makes sure that the bmh file contains the right architecture for the downstream cluster. In this case, it should be `archictecture: aarch64` in order to match with the image generated in the previous step.

--- a/telco-examples/downstream-clusters/aarch64/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/aarch64/bmh-example.yaml
@@ -19,7 +19,7 @@ spec:
   online: true
   rootDeviceHints:
     deviceName: /dev/vda
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   bmc:
     address: ${BMC_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/airgap/README.md
+++ b/telco-examples/downstream-clusters/airgap/README.md
@@ -138,7 +138,7 @@ The first step is to enroll the new baremetal host in the management cluster. To
 
 - `${BMC_USERNAME}` - The username for the BMC of the new baremetal host.
 - `${BMC_PASSWORD}` - The password for the BMC of the new baremetal host.
-- `${BMC_MAC}` - The MAC address of the new baremetal host to be used.
+- `${NODE_MAC_BOOT}` - The MAC address of the new baremetal host to be used.
 - `${BMC_ADDRESS}` - The URL for the baremetal host BMC (e.g `redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/`). If you want to know more about the different options available depending on your hardware provider, please check the following [link](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md).
 
 > **_Note:_** Please makes sure that the bmh file contains the right architecture for the downstream cluster. In this case, it should be `architecture: x86_64` in order to match with the image generated in the previous step.

--- a/telco-examples/downstream-clusters/airgap/downstream-telco-airgap/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/airgap/downstream-telco-airgap/bmh-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   bmc:

--- a/telco-examples/downstream-clusters/clusterclass/downstream-telco-clusterclass/bmh-example-type1.yaml
+++ b/telco-examples/downstream-clusters/clusterclass/downstream-telco-clusterclass/bmh-example-type1.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   bmc:
     address: ${BMC_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/clusterclass/downstream-telco-clusterclass/bmh-example-type2.yaml
+++ b/telco-examples/downstream-clusters/clusterclass/downstream-telco-clusterclass/bmh-example-type2.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   bmc:
     address: ${BMC_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node1-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node2-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node3-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node1-example.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node2-example.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node3-example.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node1-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node2-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node3-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/downstream-telco-single-node/bmh-example.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   bmc:

--- a/telco-examples/downstream-clusters/dhcp-less/dual-stack/multi-node/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/dual-stack/multi-node/bmh-example.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp-less/dual-stack/single-node/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/dual-stack/single-node/bmh-example.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp-less/ipv6/single-node/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp-less/ipv6/single-node/bmh-example.yaml
@@ -46,7 +46,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node1-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node2-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-cp-node3-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node1-example.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node2-example.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-cp-with-workers/bmh-worker-node3-example.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node1-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node1-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node2-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node2-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node3-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-metallb-multi-node/multi-node-only-cp/bmh-cp-node3-example.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     disableCertificateVerification: true

--- a/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/bmh-example.yaml
+++ b/telco-examples/downstream-clusters/dhcp/downstream-telco-single-node/bmh-example.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   bmc:

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6dhcp+route.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6dhcp+route.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6ra+dhcp.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6ra+dhcp.yaml
@@ -42,6 +42,6 @@ spec:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata
   bmc:
-    address: ${BMC_MAC}
+    address: ${NODE_MAC_BOOT}
     disableCertificateVerification: true
     credentialsName: example-demo-credentials

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6ra+dhcp_v4v6dns.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/multi-node/bmh-example_v4dhcp-v6ra+dhcp_v4v6dns.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6dhcp+route.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6dhcp+route.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6ra+dhcp.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6ra+dhcp.yaml
@@ -42,6 +42,6 @@ spec:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata
   bmc:
-    address: ${BMC_MAC}
+    address: ${NODE_MAC_BOOT}
     disableCertificateVerification: true
     credentialsName: example-demo-credentials

--- a/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6ra+dhcp_v4v6dns.yaml
+++ b/telco-examples/downstream-clusters/dhcp/dual-stack/single-node/bmh-example_v4dhcp-v6ra+dhcp_v4v6dns.yaml
@@ -44,7 +44,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_dhcp+route.yaml
+++ b/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_dhcp+route.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_slaac+dhcp+dns.yaml
+++ b/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_slaac+dhcp+dns.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_slaac+dhcp.yaml
+++ b/telco-examples/downstream-clusters/dhcp/ipv6/single-node/bmh-example_slaac+dhcp.yaml
@@ -34,7 +34,7 @@ metadata:
 spec:
   architecture: x86_64
   online: true
-  bootMACAddress: ${BMC_MAC}
+  bootMACAddress: ${NODE_MAC_BOOT}
   rootDeviceHints:
     deviceName: /dev/nvme0n1
   preprovisioningNetworkDataName: controlplane-0-networkdata

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
@@ -36,7 +36,7 @@ For each of the 3 control plane nodes:
 
 - `${BMC_NODE*_USERNAME}` - BMC username for each node
 - `${BMC_NODE*_PASSWORD}` - BMC password for each node
-- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${NODE*_MAC_BOOT}` - MAC address of the NIC on each server used to execute the PXE boot
 - `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
 
 ### In capi-multinode-basic-longhorn.yaml

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
@@ -85,6 +85,12 @@ kubectl apply -f capi-multinode-basic-longhorn.yaml
 
 ## Post-deployment verification
 
+Get cluster kubeconfig:
+
+```bash
+clusterctl get kubeconfig ${CLUSTER_NAME} > <cluster-kubeconfig>
+```
+
 Check cluster status:
 
 ```bash

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/README.md
@@ -1,0 +1,111 @@
+# BMH + CAPI Multi-Node Basic Longhorn Example
+
+This example demonstrates how to deploy a multi-node downstream cluster with basic Longhorn storage using CAPI, Metal3, and MetalLB.
+
+## Prerequisites
+
+- Management cluster deployed and running
+- 3 BareMetalHosts available for control plane nodes
+- Network connectivity configured
+- VIP address reserved for the cluster endpoint
+
+## What's included
+
+This example deploys:
+
+- 3 control plane nodes with HA configuration
+- MetalLB for VIP management
+- Endpoint Copier Operator for endpoint synchronization
+- Basic Longhorn installation (suse-storage 1.11.1)
+- Default storage settings without custom optimizations
+- No custom StorageClass (uses Longhorn chart defaults)
+- No encryption configured
+
+## Files
+
+- `bmh-cp-node1.yaml` - BareMetalHost definition for control plane node 1
+- `bmh-cp-node2.yaml` - BareMetalHost definition for control plane node 2
+- `bmh-cp-node3.yaml` - BareMetalHost definition for control plane node 3
+- `capi-multinode-basic-longhorn.yaml` - CAPI manifest with multi-node Longhorn configuration
+
+## Variables to replace
+
+### In bmh-cp-node*.yaml files
+
+For each of the 3 control plane nodes:
+
+- `${BMC_NODE*_USERNAME}` - BMC username for each node
+- `${BMC_NODE*_PASSWORD}` - BMC password for each node
+- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
+
+### In capi-multinode-basic-longhorn.yaml
+
+- `${CLUSTER_NAME}` - Name for your cluster
+- `${VIP_ADDRESS}` - VIP address for the cluster endpoint (MetalLB managed)
+- `${RKE2_VERSION}` - RKE2 version (e.g. v1.35.3+rke2r3)
+- `${IMAGE_URL}` - URL to the EIB-generated image
+- `${IMAGE_CHECKSUM_URL}` - URL to the image checksum file
+- `${DP_APPS_RANCHER_SECRET}` - Base64 encoded dockerconfigjson for dp.apps.rancher.io registry
+
+## Deployment steps
+
+### Step 1: Generate the registry secret for dp.apps.rancher.io
+
+You need credentials to pull Longhorn images from dp.apps.rancher.io. Generate the base64 encoded dockerconfigjson with your credentials:
+
+```bash
+REGISTRY_USER="your-username"
+REGISTRY_PASS="your-password"
+
+echo -n '{"auths":{"dp.apps.rancher.io":{"username":"'$REGISTRY_USER'","password":"'$REGISTRY_PASS'","auth":"'$(echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64)'"}}}' | base64 -w0
+```
+
+Copy the output and replace `${DP_APPS_RANCHER_SECRET}` in the capi-multinode-basic-longhorn.yaml file.
+
+### Step 2: Enroll the BareMetalHosts
+
+```bash
+kubectl apply -f bmh-cp-node1.yaml
+kubectl apply -f bmh-cp-node2.yaml
+kubectl apply -f bmh-cp-node3.yaml
+```
+
+Wait for all hosts to become available:
+
+```bash
+kubectl get bmh -w
+```
+
+### Step 3: Deploy the cluster
+
+```bash
+kubectl apply -f capi-multinode-basic-longhorn.yaml
+```
+
+## Post-deployment verification
+
+Check cluster status:
+
+```bash
+kubectl get cluster ${CLUSTER_NAME}
+kubectl get machines
+```
+
+Check Longhorn installation:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get pods -n longhorn-system
+kubectl --kubeconfig=<cluster-kubeconfig> get storageclass
+```
+
+Verify MetalLB and VIP:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get svc kubernetes-vip -n default
+kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
+```
+
+## Notes
+
+This is a basic multi-node example with 3 replicas for Longhorn volumes. For production deployments with encryption or CAPI in-place upgrades, use the corresponding examples.

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node1.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     credentialsName: bmc-node1-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node1-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE1_USERNAME}
+  password: ${BMC_NODE1_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: basic-longhorn-cp-node1
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE1_MAC}
+  bmc:
+    address: ${BMC_NODE1_ADDRESS}
+    credentialsName: bmc-node1-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node2.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     credentialsName: bmc-node2-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node2-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE2_USERNAME}
+  password: ${BMC_NODE2_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: basic-longhorn-cp-node2
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE2_MAC}
+  bmc:
+    address: ${BMC_NODE2_ADDRESS}
+    credentialsName: bmc-node2-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node3.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     credentialsName: bmc-node3-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/bmh-cp-node3.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node3-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE3_USERNAME}
+  password: ${BMC_NODE3_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: basic-longhorn-cp-node3
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE3_MAC}
+  bmc:
+    address: ${BMC_NODE3_ADDRESS}
+    credentialsName: bmc-node3-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/capi-multinode-basic-longhorn.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/capi-multinode-basic-longhorn.yaml
@@ -1,0 +1,313 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/18
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: Metal3Cluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: ${VIP_ADDRESS}
+    port: 6443
+  cloudProviderEnabled: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
+spec:
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+  replicas: 3
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
+  registrationAddress: ${VIP_ADDRESS}
+  serverConfig:
+    cni: calico
+    tlsSan:
+      - ${VIP_ADDRESS}
+  agentConfig:
+    format: ignition
+    additionalUserData:
+      config: |
+        variant: fcos
+        version: 1.4.0
+        storage:
+          files:
+            - path: /var/lib/rancher/rke2/server/manifests/00-endpoint-copier-operator.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: endpoint-copier-operator
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
+                    targetNamespace: endpoint-copier-operator
+                    version: 306.0.4+up1.6.0
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/01-metallb.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: metallb
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/metallb
+                    targetNamespace: metallb-system
+                    version: 306.0.2+up0.15.3
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/02-metallb-cr.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: metallb.io/v1beta1
+                  kind: IPAddressPool
+                  metadata:
+                    name: kubernetes-vip-ip-pool
+                    namespace: metallb-system
+                  spec:
+                    addresses:
+                      - ${VIP_ADDRESS}/32
+                    serviceAllocation:
+                      priority: 100
+                      namespaces:
+                        - default
+                      serviceSelectors:
+                        - matchExpressions:
+                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                  ---
+                  apiVersion: metallb.io/v1beta1
+                  kind: L2Advertisement
+                  metadata:
+                    name: ip-pool-l2-adv
+                    namespace: metallb-system
+                  spec:
+                    ipAddressPools:
+                      - kubernetes-vip-ip-pool
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/03-endpoint-svc.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: kubernetes-vip
+                    namespace: default
+                    labels:
+                      serviceType: kubernetes-vip
+                  spec:
+                    ports:
+                    - name: rke2-api
+                      port: 9345
+                      protocol: TCP
+                      targetPort: 9345
+                    - name: k8s-api
+                      port: 6443
+                      protocol: TCP
+                      targetPort: 6443
+                    type: LoadBalancer
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/04-longhorn-namespace.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: longhorn-system
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+
+            - path: /var/lib/rancher/rke2/server/manifests/05-longhorn-helm-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: kube-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/06-longhorn-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: longhorn-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/07-longhorn.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: suse-storage
+                    namespace: kube-system
+                  spec:
+                    chart: oci://dp.apps.rancher.io/charts/suse-storage
+                    dockerRegistrySecret:
+                      name: longhorn-registry
+                    targetNamespace: longhorn-system
+                    version: 1.11.1
+                    createNamespace: true
+                    valuesContent: |-
+                      privateRegistry:
+                        registryUrl: dp.apps.rancher.io
+                        registrySecret: longhorn-registry
+                      global:
+                        cattle:
+                          systemDefaultRegistry: dp.apps.rancher.io
+                      imagePullSecrets:
+                        - name: longhorn-registry
+                      longhornManager:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                      longhornDriver:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                      longhornUI:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+              mode: 0644
+        systemd:
+          units:
+            - name: rke2-preinstall.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=rke2-preinstall
+                Wants=network-online.target
+                Before=rke2-install.service
+                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                [Service]
+                Type=oneshot
+                User=root
+                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStartPost=/bin/sh -c "umount /mnt"
+                [Install]
+                WantedBy=multi-user.target
+
+    kubelet:
+      extraArgs:
+        - provider-id=metal3://BAREMETALHOST_UUID
+    nodeName: "localhost.localdomain"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: default
+spec:
+  nodeReuse: true
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
+      hostSelector:
+        matchLabels:
+          cluster-role: control-plane
+      automatedCleaningMode: disabled
+      image:
+        checksum: ${IMAGE_CHECKSUM_URL}
+        checksumType: sha256
+        format: raw
+        url: ${IMAGE_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    objectNames:
+      - key: name
+        object: machine
+      - key: local-hostname
+        object: machine
+      - key: local_hostname
+        object: machine

--- a/telco-examples/downstream-clusters/longhorn/longhorn-basic/capi-multinode-basic-longhorn.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-basic/capi-multinode-basic-longhorn.yaml
@@ -54,7 +54,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
   registrationMethod: "control-plane-endpoint"
-  registrationAddress: ${VIP_ADDRESS}
   serverConfig:
     cni: calico
     tlsSan:

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
@@ -21,6 +21,10 @@ This example deploys:
 - Encrypted StorageClass configured with 3 volume replicas and no host data locality
 - Minimal required settings for encrypted volumes
 
+## What's not included
+
+- Configuring dedicated NVMe or SSD disks for Longhorn. By default, Longhorn stores data in `/var/lib/longhorn` on the root partition. To prevent node instability caused by an exhausted root disk, it is best practice to attach additional disks. See the [Longhorn documentation](https://longhorn.io/docs/latest/nodes-and-volumes/nodes/multidisk/).
+
 ## Files
 
 - `bmh-cp-node1.yaml` - BareMetalHost definition for control plane node 1
@@ -140,7 +144,3 @@ kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
 This example uses an encrypted StorageClass configured with 3 volume replicas and no host data locality. With `defaultClass: false`, you must specify the longhorn StorageClass explicitly in your PVCs to use longhorn storage.
 
 For production deployments with CAPI in-place upgrades, use the bmh-capi-encryption-inplace-upgrade example.
-
-## What's not included
-
-- Configuring dedicated NVMe or SSD disks for Longhorn. By default, Longhorn stores data in `/var/lib/longhorn` on the root partition. To prevent node instability caused by an exhausted root disk, it is best practice to attach additional disks. See the [Longhorn documentation](https://longhorn.io/docs/latest/nodes-and-volumes/nodes/multidisk/).

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
@@ -94,6 +94,12 @@ kubectl apply -f capi-multinode-encryption.yaml
 
 ## Post-deployment verification
 
+Get cluster kubeconfig:
+
+```bash
+clusterctl get kubeconfig ${CLUSTER_NAME} > <cluster-kubeconfig>
+```
+
 Check cluster status:
 
 ```bash

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
@@ -1,0 +1,134 @@
+# BMH + CAPI Multi-Node Longhorn with Encryption Example
+
+This example demonstrates how to deploy a multi-node downstream cluster with Longhorn encrypted storage using CAPI, Metal3, and MetalLB.
+
+## Prerequisites
+
+- Management cluster deployed and running
+- 3 BareMetalHosts available for control plane nodes
+- Network connectivity configured
+- VIP address reserved for the cluster endpoint
+
+## What's included
+
+This example deploys:
+
+- 3 control plane nodes with HA configuration
+- MetalLB for VIP management
+- Endpoint Copier Operator for endpoint synchronization
+- Longhorn installation (suse-storage 1.11.1)
+- Encryption secret with LUKS/AES-256 configuration
+- Encrypted StorageClass as default
+- Minimal required settings for encrypted volumes
+
+## Files
+
+- `bmh-cp-node1.yaml` - BareMetalHost definition for control plane node 1
+- `bmh-cp-node2.yaml` - BareMetalHost definition for control plane node 2
+- `bmh-cp-node3.yaml` - BareMetalHost definition for control plane node 3
+- `capi-multinode-encryption.yaml` - CAPI manifest with multi-node Longhorn encryption configuration
+
+## Variables to replace
+
+### In bmh-cp-node*.yaml files
+
+For each of the 3 control plane nodes:
+
+- `${BMC_NODE*_USERNAME}` - BMC username for each node
+- `${BMC_NODE*_PASSWORD}` - BMC password for each node
+- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
+
+### In capi-multinode-encryption.yaml
+
+- `${CLUSTER_NAME}` - Name for your cluster
+- `${VIP_ADDRESS}` - VIP address for the cluster endpoint (MetalLB managed)
+- `${RKE2_VERSION}` - RKE2 version (e.g. v1.35.3+rke2r3)
+- `${IMAGE_URL}` - URL to the EIB-generated image
+- `${IMAGE_CHECKSUM_URL}` - URL to the image checksum file
+- `${DP_APPS_RANCHER_SECRET}` - Base64 encoded dockerconfigjson for dp.apps.rancher.io registry
+- `${ENCRYPTION_KEY}` - Base64 encryption key (generate with: openssl rand -base64 32)
+
+## Deployment steps
+
+### Step 1: Generate the registry secret for dp.apps.rancher.io
+
+You need credentials to pull Longhorn images from dp.apps.rancher.io. Generate the base64 encoded dockerconfigjson with your credentials:
+
+```bash
+REGISTRY_USER="your-username"
+REGISTRY_PASS="your-password"
+
+echo -n '{"auths":{"dp.apps.rancher.io":{"username":"'$REGISTRY_USER'","password":"'$REGISTRY_PASS'","auth":"'$(echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64)'"}}}' | base64 -w0
+```
+
+Copy the output and replace `${DP_APPS_RANCHER_SECRET}` in the capi-multinode-encryption.yaml file.
+
+### Step 2: Generate encryption key
+
+```bash
+openssl rand -base64 32
+```
+
+Copy the output and replace `${ENCRYPTION_KEY}` in capi-multinode-encryption.yaml.
+
+### Step 3: Enroll the BareMetalHosts
+
+```bash
+kubectl apply -f bmh-cp-node1.yaml
+kubectl apply -f bmh-cp-node2.yaml
+kubectl apply -f bmh-cp-node3.yaml
+```
+
+Wait for all hosts to become available:
+
+```bash
+kubectl get bmh -w
+```
+
+### Step 4: Deploy the cluster
+
+```bash
+kubectl apply -f capi-multinode-encryption.yaml
+```
+
+## Post-deployment verification
+
+Check cluster status:
+
+```bash
+kubectl get cluster ${CLUSTER_NAME}
+kubectl get machines
+```
+
+Check Longhorn installation and encryption:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get pods -n longhorn-system
+kubectl --kubeconfig=<cluster-kubeconfig> get storageclass
+kubectl --kubeconfig=<cluster-kubeconfig> get secret longhorn-crypto -n longhorn-system
+```
+
+Verify encrypted volume creation:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get volumes.longhorn.io -n longhorn-system -o json | jq '.items[] | select(.spec.encrypted == true)'
+```
+
+Verify MetalLB and VIP:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get svc kubernetes-vip -n default
+kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
+```
+
+## Security notes
+
+- Never commit the encryption key to version control
+- Store the encryption key securely (password manager, vault)
+- Without the encryption key, encrypted volumes are permanently unrecoverable
+- Consider using different keys for different clusters
+
+## Notes
+
+This example provides basic encryption configuration with 3 replicas for HA. For production deployments with CAPI in-place upgrades, use the bmh-capi-encryption-inplace-upgrade example.

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/README.md
@@ -18,7 +18,7 @@ This example deploys:
 - Endpoint Copier Operator for endpoint synchronization
 - Longhorn installation (suse-storage 1.11.1)
 - Encryption secret with LUKS/AES-256 configuration
-- Encrypted StorageClass as default
+- Encrypted StorageClass configured with 3 volume replicas and no host data locality
 - Minimal required settings for encrypted volumes
 
 ## Files
@@ -36,7 +36,7 @@ For each of the 3 control plane nodes:
 
 - `${BMC_NODE*_USERNAME}` - BMC username for each node
 - `${BMC_NODE*_PASSWORD}` - BMC password for each node
-- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${NODE*_MAC_BOOT}` - MAC address of the NIC on each server used to execute the PXE boot
 - `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
 
 ### In capi-multinode-encryption.yaml
@@ -137,4 +137,10 @@ kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
 
 ## Notes
 
-This example provides basic encryption configuration with 3 replicas for HA. For production deployments with CAPI in-place upgrades, use the bmh-capi-encryption-inplace-upgrade example.
+This example uses an encrypted StorageClass configured with 3 volume replicas and no host data locality. With `defaultClass: false`, you must specify the longhorn StorageClass explicitly in your PVCs to use longhorn storage.
+
+For production deployments with CAPI in-place upgrades, use the bmh-capi-encryption-inplace-upgrade example.
+
+## What's not included
+
+- Configuring dedicated NVMe or SSD disks for Longhorn. By default, Longhorn stores data in `/var/lib/longhorn` on the root partition. To prevent node instability caused by an exhausted root disk, it is best practice to attach additional disks. See the [Longhorn documentation](https://longhorn.io/docs/latest/nodes-and-volumes/nodes/multidisk/).

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node1-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE1_USERNAME}
+  password: ${BMC_NODE1_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: encrypted-longhorn-cp-node1
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE1_MAC}
+  bmc:
+    address: ${BMC_NODE1_ADDRESS}
+    credentialsName: bmc-node1-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node1.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     credentialsName: bmc-node1-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node2.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     credentialsName: bmc-node2-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node2-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE2_USERNAME}
+  password: ${BMC_NODE2_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: encrypted-longhorn-cp-node2
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE2_MAC}
+  bmc:
+    address: ${BMC_NODE2_ADDRESS}
+    credentialsName: bmc-node2-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node3.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node3-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE3_USERNAME}
+  password: ${BMC_NODE3_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: encrypted-longhorn-cp-node3
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE3_MAC}
+  bmc:
+    address: ${BMC_NODE3_ADDRESS}
+    credentialsName: bmc-node3-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/bmh-cp-node3.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     credentialsName: bmc-node3-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/capi-multinode-encryption.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/capi-multinode-encryption.yaml
@@ -54,7 +54,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
   registrationMethod: "control-plane-endpoint"
-  registrationAddress: ${VIP_ADDRESS}
   serverConfig:
     cni: calico
     tlsSan:

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/capi-multinode-encryption.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-encryption/capi-multinode-encryption.yaml
@@ -1,0 +1,370 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/18
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: Metal3Cluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: ${VIP_ADDRESS}
+    port: 6443
+  cloudProviderEnabled: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
+spec:
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+  replicas: 3
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
+  registrationAddress: ${VIP_ADDRESS}
+  serverConfig:
+    cni: calico
+    tlsSan:
+      - ${VIP_ADDRESS}
+  agentConfig:
+    format: ignition
+    additionalUserData:
+      config: |
+        variant: fcos
+        version: 1.4.0
+        storage:
+          files:
+            - path: /var/lib/rancher/rke2/server/manifests/00-endpoint-copier-operator.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: endpoint-copier-operator
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
+                    targetNamespace: endpoint-copier-operator
+                    version: 306.0.4+up1.6.0
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/01-metallb.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: metallb
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/metallb
+                    targetNamespace: metallb-system
+                    version: 306.0.2+up0.15.3
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/02-metallb-cr.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: metallb.io/v1beta1
+                  kind: IPAddressPool
+                  metadata:
+                    name: kubernetes-vip-ip-pool
+                    namespace: metallb-system
+                  spec:
+                    addresses:
+                      - ${VIP_ADDRESS}/32
+                    serviceAllocation:
+                      priority: 100
+                      namespaces:
+                        - default
+                      serviceSelectors:
+                        - matchExpressions:
+                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                  ---
+                  apiVersion: metallb.io/v1beta1
+                  kind: L2Advertisement
+                  metadata:
+                    name: ip-pool-l2-adv
+                    namespace: metallb-system
+                  spec:
+                    ipAddressPools:
+                      - kubernetes-vip-ip-pool
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/03-endpoint-svc.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: kubernetes-vip
+                    namespace: default
+                    labels:
+                      serviceType: kubernetes-vip
+                  spec:
+                    ports:
+                    - name: rke2-api
+                      port: 9345
+                      protocol: TCP
+                      targetPort: 9345
+                    - name: k8s-api
+                      port: 6443
+                      protocol: TCP
+                      targetPort: 6443
+                    type: LoadBalancer
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/04-longhorn-namespace.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: longhorn-system
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/05-longhorn-helm-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: kube-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/06-longhorn-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: longhorn-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/07-longhorn.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: suse-storage
+                    namespace: kube-system
+                  spec:
+                    chart: oci://dp.apps.rancher.io/charts/suse-storage
+                    dockerRegistrySecret:
+                      name: longhorn-registry
+                    targetNamespace: longhorn-system
+                    version: 1.11.1
+                    createNamespace: true
+                    valuesContent: |-
+                      privateRegistry:
+                        registryUrl: dp.apps.rancher.io
+                        registrySecret: longhorn-registry
+                      global:
+                        cattle:
+                          systemDefaultRegistry: dp.apps.rancher.io
+                      imagePullSecrets:
+                        - name: longhorn-registry
+                      persistence:
+                        defaultClass: false
+                        defaultClassReplicaCount: 3
+                        defaultDataLocality: disabled
+                        reclaimPolicy: Delete
+                      longhornManager:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                      longhornDriver:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                      longhornUI:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/08-longhorn-encryption-secret.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-crypto
+                    namespace: longhorn-system
+                  type: Opaque
+                  stringData:
+                    CRYPTO_KEY_VALUE: "${ENCRYPTION_KEY}"
+                    CRYPTO_KEY_PROVIDER: "secret"
+                    CRYPTO_KEY_CIPHER: "aes-xts-plain64"
+                    CRYPTO_KEY_HASH: "sha256"
+                    CRYPTO_KEY_SIZE: "256"
+                    CRYPTO_PBKDF: "argon2i"
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/09-longhorn-encrypted-storageclass.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: storage.k8s.io/v1
+                  kind: StorageClass
+                  metadata:
+                    name: longhorn-encrypted
+                    annotations:
+                      storageclass.kubernetes.io/is-default-class: "true"
+                  provisioner: driver.longhorn.io
+                  allowVolumeExpansion: true
+                  reclaimPolicy: Delete
+                  volumeBindingMode: Immediate
+                  parameters:
+                    numberOfReplicas: "3"
+                    dataLocality: "disabled"
+                    fsType: "ext4"
+                    fromBackup: ""
+                    encrypted: "true"
+                    csi.storage.k8s.io/provisioner-secret-name: "longhorn-crypto"
+                    csi.storage.k8s.io/provisioner-secret-namespace: "longhorn-system"
+                    csi.storage.k8s.io/node-publish-secret-name: "longhorn-crypto"
+                    csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
+                    csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
+                    csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+              mode: 0644
+        systemd:
+          units:
+            - name: rke2-preinstall.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=rke2-preinstall
+                Wants=network-online.target
+                Before=rke2-install.service
+                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                [Service]
+                Type=oneshot
+                User=root
+                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStartPost=/bin/sh -c "umount /mnt"
+                [Install]
+                WantedBy=multi-user.target
+
+    kubelet:
+      extraArgs:
+        - provider-id=metal3://BAREMETALHOST_UUID
+    nodeName: "localhost.localdomain"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: default
+spec:
+  nodeReuse: true
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
+      hostSelector:
+        matchLabels:
+          cluster-role: control-plane
+      automatedCleaningMode: disabled
+      image:
+        checksum: ${IMAGE_CHECKSUM_URL}
+        checksumType: sha256
+        format: raw
+        url: ${IMAGE_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    objectNames:
+      - key: name
+        object: machine
+      - key: local-hostname
+        object: machine
+      - key: local_hostname
+        object: machine

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
@@ -1,0 +1,162 @@
+# BMH + CAPI Multi-Node Longhorn with In-Place Upgrade Example
+
+This example demonstrates how to deploy a multi-node downstream cluster with Longhorn storage optimized for CAPI in-place upgrades using Metal3 nodeReuse, MetalLB, and Endpoint Copier.
+
+## Prerequisites
+
+- Management cluster deployed and running
+- 3 BareMetalHosts available for control plane nodes
+- Network connectivity configured
+- VIP address reserved for the cluster endpoint
+
+## What's included
+
+This example deploys:
+
+- 3 control plane nodes with HA configuration
+- MetalLB for VIP management
+- Endpoint Copier Operator for endpoint synchronization
+- Longhorn installation (suse-storage 1.11.1)
+- StorageClass with staleReplicaTimeout optimized for upgrades
+- Critical settings for CAPI in-place upgrades (nodeReuse=true)
+- Settings to prevent PDB blocking during node drain
+- No encryption configured (for encryption, use bmh-capi-encryption example)
+
+## Files
+
+- `bmh-cp-node1.yaml` - BareMetalHost definition for control plane node 1
+- `bmh-cp-node2.yaml` - BareMetalHost definition for control plane node 2
+- `bmh-cp-node3.yaml` - BareMetalHost definition for control plane node 3
+- `capi-multinode-inplace-upgrade.yaml` - CAPI manifest with Longhorn in-place upgrade optimizations
+
+## Variables to replace
+
+### In bmh-cp-node*.yaml files
+
+For each of the 3 control plane nodes:
+
+- `${BMC_NODE*_USERNAME}` - BMC username for each node
+- `${BMC_NODE*_PASSWORD}` - BMC password for each node
+- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
+
+### In capi-multinode-inplace-upgrade.yaml
+
+- `${CLUSTER_NAME}` - Name for your cluster
+- `${VIP_ADDRESS}` - VIP address for the cluster endpoint (MetalLB managed)
+- `${RKE2_VERSION}` - RKE2 version (e.g. v1.35.3+rke2r3)
+- `${IMAGE_URL}` - URL to the EIB-generated image
+- `${IMAGE_CHECKSUM_URL}` - URL to the image checksum file
+- `${DP_APPS_RANCHER_SECRET}` - Base64 encoded dockerconfigjson for dp.apps.rancher.io registry
+
+## CAPI In-Place Upgrade Settings
+
+This example includes critical configuration for CAPI in-place upgrades where nodes reboot but keep their data:
+
+### staleReplicaTimeout: "60"
+
+Wait 60 minutes before cleaning up stale replicas during node downtime. The default 30 minutes is too short for some upgrade scenarios. This prevents premature replica rebuilds when nodes return quickly.
+
+Without this setting, Longhorn may mark replicas as stale and start unnecessary rebuilds during normal upgrade operations, wasting time and resources.
+
+### nodeDrainPolicy: "always-allow"
+
+Allow node drain even with last healthy replica. Required for CAPI rolling upgrades to proceed without manual intervention. Safe for nodeReuse because the node returns with the same data.
+
+### replicaReplenishmentWaitInterval: 300
+
+Wait 5 minutes before creating new replicas during node reboots. Prevents unnecessary replica creation when nodes return quickly from in-place upgrades.
+
+## Deployment steps
+
+### Step 1: Generate the registry secret for dp.apps.rancher.io
+
+You need credentials to pull Longhorn images from dp.apps.rancher.io. Generate the base64 encoded dockerconfigjson with your credentials:
+
+```bash
+REGISTRY_USER="your-username"
+REGISTRY_PASS="your-password"
+
+echo -n '{"auths":{"dp.apps.rancher.io":{"username":"'$REGISTRY_USER'","password":"'$REGISTRY_PASS'","auth":"'$(echo -n "$REGISTRY_USER:$REGISTRY_PASS" | base64)'"}}}' | base64 -w0
+```
+
+Copy the output and replace `${DP_APPS_RANCHER_SECRET}` in the capi-multinode-inplace-upgrade.yaml file.
+
+### Step 2: Enroll the BareMetalHosts
+
+```bash
+kubectl apply -f bmh-cp-node1.yaml
+kubectl apply -f bmh-cp-node2.yaml
+kubectl apply -f bmh-cp-node3.yaml
+```
+
+Wait for all hosts to become available:
+
+```bash
+kubectl get bmh -w
+```
+
+### Step 3: Deploy the cluster
+
+```bash
+kubectl apply -f capi-multinode-inplace-upgrade.yaml
+```
+
+## Post-deployment verification
+
+Check cluster status:
+
+```bash
+kubectl get cluster ${CLUSTER_NAME}
+kubectl get machines
+```
+
+Check Longhorn installation and configuration:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get pods -n longhorn-system
+kubectl --kubeconfig=<cluster-kubeconfig> get storageclass
+```
+
+Verify settings:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system node-drain-policy -o jsonpath='{.value}'
+kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system replica-replenishment-wait-interval -o jsonpath='{.value}'
+kubectl --kubeconfig=<cluster-kubeconfig> get storageclass longhorn -o jsonpath='{.parameters.staleReplicaTimeout}'
+```
+
+Verify MetalLB and VIP:
+
+```bash
+kubectl --kubeconfig=<cluster-kubeconfig> get svc kubernetes-vip -n default
+kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
+```
+
+## Performing CAPI In-Place Upgrades
+
+To upgrade the cluster:
+
+1. Update the RKE2 version in the manifest:
+
+```bash
+kubectl patch rke2controlplane ${CLUSTER_NAME} --type merge -p '{"spec":{"version":"v1.35.4+rke2r1"}}'
+```
+
+2. Monitor the upgrade:
+
+```bash
+kubectl get machines -w
+kubectl get bmh -w
+```
+
+The upgrade will proceed automatically with Longhorn handling replica management according to the optimized settings. Each node will reboot one at a time, and Longhorn will wait for the node to return before rebuilding replicas.
+
+## References
+
+For detailed technical information about these settings:
+
+- [Longhorn Issue 8362](https://github.com/longhorn/longhorn/issues/8362) - CAPI Rolling Upgrade Investigation
+- [Longhorn Issue 2639](https://github.com/longhorn/longhorn/issues/2639) - PDB blocking node drain
+- [Metal3 Node Reuse Documentation](https://book.metal3.io/capm3/node_reuse)
+

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
@@ -104,6 +104,12 @@ kubectl apply -f capi-multinode-inplace-upgrade.yaml
 
 ## Post-deployment verification
 
+Get cluster kubeconfig:
+
+```bash
+clusterctl get kubeconfig ${CLUSTER_NAME} > <cluster-kubeconfig>
+```
+
 Check cluster status:
 
 ```bash
@@ -121,9 +127,9 @@ kubectl --kubeconfig=<cluster-kubeconfig> get storageclass
 Verify settings:
 
 ```bash
-kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system node-drain-policy -o jsonpath='{.value}'
-kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system replica-replenishment-wait-interval -o jsonpath='{.value}'
-kubectl --kubeconfig=<cluster-kubeconfig> get storageclass longhorn -o jsonpath='{.parameters.staleReplicaTimeout}'
+kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system node-drain-policy -o jsonpath='{.value}{"\n"}'
+kubectl --kubeconfig=<cluster-kubeconfig> get settings.longhorn.io -n longhorn-system replica-replenishment-wait-interval -o jsonpath='{.value}{"\n"}'
+kubectl --kubeconfig=<cluster-kubeconfig> get storageclass longhorn -o jsonpath='{.parameters.staleReplicaTimeout}{"\n"}'
 ```
 
 Verify MetalLB and VIP:
@@ -137,7 +143,7 @@ kubectl --kubeconfig=<cluster-kubeconfig> get ipaddresspool -n metallb-system
 
 To upgrade the cluster:
 
-1. Update the RKE2 version in the manifest:
+1. Update the RKE2 version in the manifest (this example uses v1.35.4+rke2r1 for testing purposes, adjust to match your STC release version):
 
 ```bash
 kubectl patch rke2controlplane ${CLUSTER_NAME} --type merge -p '{"spec":{"version":"v1.35.4+rke2r1"}}'

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/README.md
@@ -17,10 +17,14 @@ This example deploys:
 - MetalLB for VIP management
 - Endpoint Copier Operator for endpoint synchronization
 - Longhorn installation (suse-storage 1.11.1)
-- StorageClass with staleReplicaTimeout optimized for upgrades
+- Uses `longhorn`, a non-encrypted StorageClass with staleReplicaTimeout optimized for upgrades. It uses 3 volume replicas and best-effort host data locality
 - Critical settings for CAPI in-place upgrades (nodeReuse=true)
-- Settings to prevent PDB blocking during node drain
+- Settings to prevent PDB (Pod Disruption Budget) blocking during node drain
 - No encryption configured (for encryption, use bmh-capi-encryption example)
+
+## What's not included
+
+- Configuring dedicated NVMe or SSD disks for Longhorn. By default, Longhorn stores data in `/var/lib/longhorn` on the root partition. To prevent node instability caused by an exhausted root disk, it is best practice to attach additional disks. See the [Longhorn documentation](https://longhorn.io/docs/latest/nodes-and-volumes/nodes/multidisk/).
 
 ## Files
 
@@ -37,7 +41,7 @@ For each of the 3 control plane nodes:
 
 - `${BMC_NODE*_USERNAME}` - BMC username for each node
 - `${BMC_NODE*_PASSWORD}` - BMC password for each node
-- `${BMC_NODE*_MAC}` - MAC address of each server
+- `${NODE*_MAC_BOOT}` - MAC address of the NIC on each server used to execute the PXE boot
 - `${BMC_NODE*_ADDRESS}` - BMC URL for each node (e.g. redfish-virtualmedia://192.168.200.75/redfish/v1/Systems/1/)
 
 ### In capi-multinode-inplace-upgrade.yaml

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node1.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node1-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE1_USERNAME}
+  password: ${BMC_NODE1_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: longhorn-inplace-cp-node1
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE1_MAC}
+  bmc:
+    address: ${BMC_NODE1_ADDRESS}
+    credentialsName: bmc-node1-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node1.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node1.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE1_MAC}
+  bootMACAddress: ${NODE1_MAC_BOOT}
   bmc:
     address: ${BMC_NODE1_ADDRESS}
     credentialsName: bmc-node1-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node2.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node2-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE2_USERNAME}
+  password: ${BMC_NODE2_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: longhorn-inplace-cp-node2
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE2_MAC}
+  bmc:
+    address: ${BMC_NODE2_ADDRESS}
+    credentialsName: bmc-node2-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node2.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node2.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE2_MAC}
+  bootMACAddress: ${NODE2_MAC_BOOT}
   bmc:
     address: ${BMC_NODE2_ADDRESS}
     credentialsName: bmc-node2-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node3.yaml
@@ -17,7 +17,7 @@ metadata:
     cluster-role: control-plane
 spec:
   online: true
-  bootMACAddress: ${BMC_NODE3_MAC}
+  bootMACAddress: ${NODE3_MAC_BOOT}
   bmc:
     address: ${BMC_NODE3_ADDRESS}
     credentialsName: bmc-node3-credentials

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node3.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/bmh-cp-node3.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bmc-node3-credentials
+  namespace: default
+type: Opaque
+stringData:
+  username: ${BMC_NODE3_USERNAME}
+  password: ${BMC_NODE3_PASSWORD}
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: longhorn-inplace-cp-node3
+  namespace: default
+  labels:
+    cluster-role: control-plane
+spec:
+  online: true
+  bootMACAddress: ${BMC_NODE3_MAC}
+  bmc:
+    address: ${BMC_NODE3_ADDRESS}
+    credentialsName: bmc-node3-credentials
+  automatedCleaningMode: disabled

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/capi-multinode-inplace-upgrade.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/capi-multinode-inplace-upgrade.yaml
@@ -1,0 +1,370 @@
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  labels:
+    cluster-api.cattle.io/rancher-auto-import: "true"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/18
+    services:
+      cidrBlocks:
+      - 10.96.0.0/12
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: RKE2ControlPlane
+    name: ${CLUSTER_NAME}
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: Metal3Cluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: ${VIP_ADDRESS}
+    port: 6443
+  cloudProviderEnabled: false
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: RKE2ControlPlane
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+  annotations:
+    rke2.controlplane.cluster.x-k8s.io/load-balancer-exclusion: "true"
+spec:
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: ${CLUSTER_NAME}-controlplane
+  replicas: 3
+  version: ${RKE2_VERSION}
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 0
+  registrationMethod: "control-plane-endpoint"
+  registrationAddress: ${VIP_ADDRESS}
+  serverConfig:
+    cni: calico
+    tlsSan:
+      - ${VIP_ADDRESS}
+  agentConfig:
+    format: ignition
+    additionalUserData:
+      config: |
+        variant: fcos
+        version: 1.4.0
+        storage:
+          files:
+            - path: /var/lib/rancher/rke2/server/manifests/00-endpoint-copier-operator.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: endpoint-copier-operator
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/endpoint-copier-operator
+                    targetNamespace: endpoint-copier-operator
+                    version: 306.0.4+up1.6.0
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/01-metallb.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: metallb
+                    namespace: kube-system
+                  spec:
+                    chart: oci://registry.suse.com/edge/charts/metallb
+                    targetNamespace: metallb-system
+                    version: 306.0.2+up0.15.3
+                    createNamespace: true
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/02-metallb-cr.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: metallb.io/v1beta1
+                  kind: IPAddressPool
+                  metadata:
+                    name: kubernetes-vip-ip-pool
+                    namespace: metallb-system
+                  spec:
+                    addresses:
+                      - ${VIP_ADDRESS}/32
+                    serviceAllocation:
+                      priority: 100
+                      namespaces:
+                        - default
+                      serviceSelectors:
+                        - matchExpressions:
+                          - {key: "serviceType", operator: In, values: [kubernetes-vip]}
+                  ---
+                  apiVersion: metallb.io/v1beta1
+                  kind: L2Advertisement
+                  metadata:
+                    name: ip-pool-l2-adv
+                    namespace: metallb-system
+                  spec:
+                    ipAddressPools:
+                      - kubernetes-vip-ip-pool
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/03-endpoint-svc.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: kubernetes-vip
+                    namespace: default
+                    labels:
+                      serviceType: kubernetes-vip
+                  spec:
+                    ports:
+                    - name: rke2-api
+                      port: 9345
+                      protocol: TCP
+                      targetPort: 9345
+                    - name: k8s-api
+                      port: 6443
+                      protocol: TCP
+                      targetPort: 6443
+                    type: LoadBalancer
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/04-longhorn-namespace.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: longhorn-system
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/05-longhorn-helm-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: kube-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/06-longhorn-auth.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: v1
+                  kind: Secret
+                  metadata:
+                    name: longhorn-registry
+                    namespace: longhorn-system
+                  type: kubernetes.io/dockerconfigjson
+                  data:
+                    .dockerconfigjson: ${DP_APPS_RANCHER_SECRET}
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/07-longhorn.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: helm.cattle.io/v1
+                  kind: HelmChart
+                  metadata:
+                    name: suse-storage
+                    namespace: kube-system
+                  spec:
+                    chart: oci://dp.apps.rancher.io/charts/suse-storage
+                    dockerRegistrySecret:
+                      name: longhorn-registry
+                    targetNamespace: longhorn-system
+                    version: 1.11.1
+                    createNamespace: true
+                    valuesContent: |-
+                      privateRegistry:
+                        registryUrl: dp.apps.rancher.io
+                        registrySecret: longhorn-registry
+                      global:
+                        cattle:
+                          systemDefaultRegistry: dp.apps.rancher.io
+                      imagePullSecrets:
+                        - name: longhorn-registry
+                      defaultSettings:
+                        nodeDrainPolicy: "always-allow"
+                        replicaReplenishmentWaitInterval: 300
+                        autoDeletePodWhenVolumeDetachedUnexpectedly: true
+                      persistence:
+                        defaultClass: false
+                        defaultClassReplicaCount: 3
+                        defaultDataLocality: best-effort
+                        reclaimPolicy: Retain
+                      longhornManager:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                        resources:
+                          limits:
+                            memory: 512Mi
+                          requests:
+                            cpu: 100m
+                            memory: 256Mi
+                        tolerations:
+                          - key: "node-role.kubernetes.io/control-plane"
+                            operator: "Exists"
+                            effect: "NoSchedule"
+                      longhornDriver:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+                        resources:
+                          limits:
+                            memory: 256Mi
+                          requests:
+                            cpu: 50m
+                            memory: 128Mi
+                        tolerations:
+                          - key: "node-role.kubernetes.io/control-plane"
+                            operator: "Exists"
+                            effect: "NoSchedule"
+                      longhornUI:
+                        imagePullSecrets:
+                          - name: longhorn-registry
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+            - path: /var/lib/rancher/rke2/server/manifests/08-longhorn-storageclass.yaml
+              overwrite: true
+              contents:
+                inline: |
+                  apiVersion: storage.k8s.io/v1
+                  kind: StorageClass
+                  metadata:
+                    name: longhorn
+                    annotations:
+                      storageclass.kubernetes.io/is-default-class: "true"
+                  provisioner: driver.longhorn.io
+                  allowVolumeExpansion: true
+                  reclaimPolicy: Retain
+                  volumeBindingMode: Immediate
+                  parameters:
+                    numberOfReplicas: "3"
+                    staleReplicaTimeout: "60"
+                    dataLocality: "best-effort"
+                    fsType: "ext4"
+                    fromBackup: ""
+                    disableRevisionCounter: "true"
+              mode: 0644
+              user:
+                name: root
+              group:
+                name: root
+        systemd:
+          units:
+            - name: rke2-preinstall.service
+              enabled: true
+              contents: |
+                [Unit]
+                Description=rke2-preinstall
+                Wants=network-online.target
+                Before=rke2-install.service
+                ConditionPathExists=!/run/cluster-api/bootstrap-success.complete
+                [Service]
+                Type=oneshot
+                User=root
+                ExecStartPre=/bin/sh -c "mount -L config-2 /mnt"
+                ExecStart=/bin/sh -c "sed -i \"s/BAREMETALHOST_UUID/$(jq -r .uuid /mnt/openstack/latest/meta_data.json)/\" /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-name: $(jq -r .name /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"node-label:\" >> /etc/rancher/rke2/config.yaml"
+                ExecStart=/bin/sh -c "echo \"  - metal3.io/uuid=$(jq -r .uuid /mnt/openstack/latest/meta_data.json)\" >> /etc/rancher/rke2/config.yaml"
+                ExecStartPost=/bin/sh -c "umount /mnt"
+                [Install]
+                WantedBy=multi-user.target
+    kubelet:
+      extraArgs:
+        - provider-id=metal3://BAREMETALHOST_UUID
+    nodeName: "localhost.localdomain"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+  namespace: default
+spec:
+  nodeReuse: true
+  template:
+    spec:
+      dataTemplate:
+        name: ${CLUSTER_NAME}-controlplane-template
+      hostSelector:
+        matchLabels:
+          cluster-role: control-plane
+      automatedCleaningMode: disabled
+      image:
+        checksum: ${IMAGE_CHECKSUM_URL}
+        checksumType: sha256
+        format: raw
+        url: ${IMAGE_URL}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3DataTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane-template
+  namespace: default
+spec:
+  clusterName: ${CLUSTER_NAME}
+  metaData:
+    objectNames:
+      - key: name
+        object: machine
+      - key: local-hostname
+        object: machine
+      - key: local_hostname
+        object: machine

--- a/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/capi-multinode-inplace-upgrade.yaml
+++ b/telco-examples/downstream-clusters/longhorn/longhorn-with-improvements-inplace-upgrades/capi-multinode-inplace-upgrade.yaml
@@ -54,7 +54,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
   registrationMethod: "control-plane-endpoint"
-  registrationAddress: ${VIP_ADDRESS}
   serverConfig:
     cni: calico
     tlsSan:


### PR DESCRIPTION
This pull request introduces new example configurations for deploying downstream clusters with Longhorn storage using BareMetalHost (BMH), Cluster API (CAPI), and Metal3. It adds both a basic multi-node Longhorn scenario and a scenario with Longhorn encryption, including all supporting manifests and documentation. Additionally, the main `README.md` is updated to reference these new Longhorn scenarios.

**New Longhorn downstream cluster scenarios:**

*Documentation and manifests for basic Longhorn:*
- Added a new example (`bmh-capi-basic-longhorn`) showing how to deploy a multi-node downstream cluster with basic Longhorn storage, including a comprehensive README and manifests for three control plane nodes and the main CAPI cluster definition. [[1]](diffhunk://#diff-d467b24ef555cdce5fd7fae61ab538b6f077529333f747afb41ea450d9c73fb8R1-R111) [[2]](diffhunk://#diff-8ca3f228269bcb14688985c5f7c8b914446d15dfbc3ab27363cf7f190f0cef17R1-R24) [[3]](diffhunk://#diff-64d2a69d1cc0da47d10b2bcd82eaa2d9261df5c8b441e45a428b624d71c289b1R1-R24) [[4]](diffhunk://#diff-67fe17a1ca813c956b8883de58e8c51be2ae4437314f7166a70d4bed9dad532fR1-R24) [[5]](diffhunk://#diff-854febbfad3224eed4194887585c81d2efa492b049a7b087f57121646ed2a80aR1-R313)

*Documentation and manifests for Longhorn with encryption:*
- Added a new example (`bmh-capi-encryption`) for deploying a multi-node downstream cluster with Longhorn storage encryption, including a detailed README and manifests for three control plane nodes and the encrypted CAPI cluster definition. [[1]](diffhunk://#diff-0c5c875f76e46b11b5d3a5f12137883b18d60e0059e7212b381a1c5e759f0667R1-R134) [[2]](diffhunk://#diff-f49c5297817329bd43797c6a443d842235df614b055cf9e3f8be08281e46163fR1-R24) [[3]](diffhunk://#diff-092e17adacf86641c14133ec7aa3aecf9ae6436664afbd7215f2fc2877e23d48R1-R24) [[4]](diffhunk://#diff-48975fd8f950c1a19ce1517b69741a7ecf6b050db7f239435488f2adfdac902bR1-R24)

**Documentation updates:**

*Main README update:*
- Updated the main `README.md` to mention the new Longhorn scenarios for downstream clusters, making users aware of the added examples.